### PR TITLE
feat: Exclude Bots From Contributors Card

### DIFF
--- a/packages/gitlab/src/api/GitlabCIClient.ts
+++ b/packages/gitlab/src/api/GitlabCIClient.ts
@@ -138,6 +138,7 @@ export class GitlabCIClient implements GitlabCIApi {
                 Record<string, unknown>[]
             >('users', {
                 search: contributorsData[i].email,
+                without_project_bots: true,
             });
             if (userProfile) {
                 userProfile.forEach(
@@ -162,7 +163,9 @@ export class GitlabCIClient implements GitlabCIApi {
             username = username.slice(1);
         }
         const userDetail = (
-            await this.callApi<PeopleCardEntityData[]>('users', { username })
+            await this.callApi<PeopleCardEntityData[]>('users', {
+                username,
+            })
         )?.[0];
 
         if (!userDetail) throw new Error(`user ${username} does not exist`);

--- a/packages/gitlab/src/api/GitlabCIClient.ts
+++ b/packages/gitlab/src/api/GitlabCIClient.ts
@@ -138,7 +138,7 @@ export class GitlabCIClient implements GitlabCIApi {
                 Record<string, unknown>[]
             >('users', {
                 search: contributorsData[i].email,
-                without_project_bots: true,
+                without_project_bots: 'true',
             });
             if (userProfile) {
                 userProfile.forEach(


### PR DESCRIPTION
Hello team! :wave: 

As per the documentation, I added `without_project_bots=true` to the query parameters for the `/users` API call.

## 🚨 Proposed changes

As above, this should not import bot users from projects or groups.

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor

**Note** I would like to add or modify the tests for this but was struggling a little bit to find out how you guys are actually testing the API calls and the mock data is a bit of a beast to comb through, could you help me out on this part? I would like to add a bot user to the mock data and make sure it does not get imported. I did run a courtesy `yarn test` and at the very least it did **not** break anything :sweat_smile: 

Any and all feedback is welcome! :+1: 

Thanks a lot!
