### PR TITLE
[Feature] Allow use when authentication is enabled on Backstage backend

### DIFF
--- a/packages/gitlab/src/plugin.ts
+++ b/packages/gitlab/src/plugin.ts
@@ -2,6 +2,7 @@ import {
     createComponentExtension,
     createPlugin,
     createRoutableExtension,
+    identityApiRef,
 } from '@backstage/core-plugin-api';
 
 import {
@@ -21,10 +22,11 @@ export const gitlabPlugin = createPlugin({
     apis: [
         createApiFactory({
             api: GitlabCIApiRef,
-            deps: { configApi: configApiRef, discoveryApi: discoveryApiRef },
-            factory: ({ configApi, discoveryApi }) =>
+            deps: { configApi: configApiRef, discoveryApi: discoveryApiRef, identityApi: identityApiRef },
+            factory: ({ configApi, discoveryApi, identityApi }) =>
                 GitlabCIClient.setupAPI({
                     discoveryApi,
+                    identityApi,
                     codeOwnersPath: configApi.getOptionalString(
                         'gitlab.defaultCodeOwnersPath'
                     ),


### PR DESCRIPTION
## 🚨 Proposed changes

  Currently the plugin won't work on Backstage deployments that have authentication enabled in the middleware. Requests from the frontend fail with `401 Unauthorized` since the `Authorization` header is not populated.

  This PR uses the *IdentityAPI* to determine if there is an identity token in the session and will use it to populate the `Authorization` header with a *Bearer* token.

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [ ] New feature (non-breaking change which adds functionality)
-   [X] Bugfix (non-breaking change which fixes an issue)
-   [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor

