### PR TITLE
feat(api): identify gitlab instances by hostname

### DIFF
--- a/packages/gitlab-backend/src/processor/processor.test.ts
+++ b/packages/gitlab-backend/src/processor/processor.test.ts
@@ -50,7 +50,9 @@ describe('Processor', () => {
         expect(entity.metadata?.annotations?.[GITLAB_PROJECT_SLUG]).toEqual(
             'backstage/backstage'
         );
-        expect(entity.metadata?.annotations?.[GITLAB_INSTANCE]).toEqual('0');
+        expect(entity.metadata?.annotations?.[GITLAB_INSTANCE]).toEqual(
+            'my.custom-gitlab.com'
+        );
     });
 
     it('Processor creates the right annotation for second instance', async () => {
@@ -74,7 +76,9 @@ describe('Processor', () => {
         expect(entity.metadata?.annotations?.[GITLAB_PROJECT_SLUG]).toEqual(
             'backstage/backstage'
         );
-        expect(entity.metadata?.annotations?.[GITLAB_INSTANCE]).toEqual('1');
+        expect(entity.metadata?.annotations?.[GITLAB_INSTANCE]).toEqual(
+            'my.second-custom-gitlab.com'
+        );
     });
 
     it('Processor creates the right annotation for old gitlab instance', async () => {
@@ -98,7 +102,9 @@ describe('Processor', () => {
         expect(entity.metadata?.annotations?.[GITLAB_PROJECT_SLUG]).toEqual(
             'backstage/backstage'
         );
-        expect(entity.metadata?.annotations?.[GITLAB_INSTANCE]).toEqual('0');
+        expect(entity.metadata?.annotations?.[GITLAB_INSTANCE]).toEqual(
+            'my.custom-gitlab.com'
+        );
     });
 
     it('The processor does not update GITLAB_PROJECT_SLUG if the annotations GITLAB_PROJECT_ID or GITLAB_PROJECT_SLUG exist', async () => {
@@ -126,7 +132,9 @@ describe('Processor', () => {
         expect(
             entity.metadata?.annotations?.[GITLAB_PROJECT_SLUG]
         ).toBeUndefined();
-        expect(entity.metadata?.annotations?.[GITLAB_INSTANCE]).toEqual('0');
+        expect(entity.metadata?.annotations?.[GITLAB_INSTANCE]).toEqual(
+            'my.custom-gitlab.com'
+        );
 
         expect(entity.metadata?.annotations?.[GITLAB_PROJECT_ID]).toEqual(
             projectId
@@ -141,7 +149,7 @@ describe('Processor', () => {
             metadata: {
                 name: 'backstage',
                 annotations: {
-                    [GITLAB_INSTANCE]: '1',
+                    [GITLAB_INSTANCE]: 'my.custom-gitlab.com',
                 },
             },
         };
@@ -157,7 +165,9 @@ describe('Processor', () => {
         expect(entity.metadata?.annotations?.[GITLAB_PROJECT_SLUG]).toEqual(
             'backstage/backstage'
         );
-        expect(entity.metadata?.annotations?.[GITLAB_INSTANCE]).toEqual('1');
+        expect(entity.metadata?.annotations?.[GITLAB_INSTANCE]).toEqual(
+            'my.custom-gitlab.com'
+        );
 
         expect(
             entity.metadata?.annotations?.[GITLAB_PROJECT_ID]

--- a/packages/gitlab-backend/src/service/router.test.ts
+++ b/packages/gitlab-backend/src/service/router.test.ts
@@ -79,7 +79,9 @@ describe('createRouter', () => {
             const agent = request.agent(app);
             // this is set to let msw pass test requests through the mock server
             agent.set('User-Agent', 'supertest');
-            const response = await agent.get('/api/gitlab/0/projects/434');
+            const response = await agent.get(
+                '/api/gitlab/non-existing-example.com/projects/434'
+            );
             expect(response.status).toEqual(200);
             expect(response.body).toEqual({
                 headers: {
@@ -96,7 +98,9 @@ describe('createRouter', () => {
             const agent = request.agent(app);
             // this is set to let msw pass test requests through the mock server
             agent.set('User-Agent', 'supertest');
-            const response = await agent.get('/api/gitlab/1/projects/434');
+            const response = await agent.get(
+                '/api/gitlab/non-existing-example-2.com/projects/434'
+            );
             expect(response.status).toEqual(200);
             expect(response.body).toEqual({
                 headers: {
@@ -125,7 +129,7 @@ describe('createRouter', () => {
             ]) {
                 // @ts-ignore
                 const response = await agent?.[method](
-                    '/api/gitlab/1/projects/434'
+                    '/api/gitlab/non-existing-example-2.com/projects/434'
                 );
                 expect(response.status).toEqual(404);
                 expect(response.body).toEqual({});
@@ -136,7 +140,9 @@ describe('createRouter', () => {
             const agent = request.agent(app);
             // this is set to let msw pass test requests through the mock server
             agent.set('User-Agent', 'supertest');
-            const response = await agent.get('/api/gitlab/3/projects/434');
+            const response = await agent.get(
+                '/api/gitlab/does.not.exist/projects/434'
+            );
             expect(response.status).toEqual(404);
             expect(response.body).toEqual({});
         });

--- a/packages/gitlab/src/components/widgets/LanguagesCard/LanguagesCard.tsx
+++ b/packages/gitlab/src/components/widgets/LanguagesCard/LanguagesCard.tsx
@@ -55,7 +55,7 @@ export const LanguagesCard = ({}) => {
     const project_slug = gitlabProjectSlug();
     const gitlab_instance = gitlabInstance();
 
-    const GitlabCIAPI = useApi(GitlabCIApiRef).build(gitlab_instance || '0');
+    const GitlabCIAPI = useApi(GitlabCIApiRef).build(gitlab_instance || 'gitlab.com');
 
     const { value, loading, error } = useAsync(async (): Promise<Language> => {
         const projectDetails: any = await GitlabCIAPI.getProjectDetails(

--- a/packages/gitlab/src/components/widgets/MergeRequestStats/MergeRequestStats.tsx
+++ b/packages/gitlab/src/components/widgets/MergeRequestStats/MergeRequestStats.tsx
@@ -64,7 +64,7 @@ const MergeRequestStats = (props: Props) => {
     const project_slug = gitlabProjectSlug();
     const gitlab_instance = gitlabInstance();
 
-    const GitlabCIAPI = useApi(GitlabCIApiRef).build(gitlab_instance || '0');
+    const GitlabCIAPI = useApi(GitlabCIApiRef).build(gitlab_instance || 'gitlab.com');
     const mergeStat: MergeRequestStatsCount = {
         avgTimeUntilMerge: 0,
         closedCount: 0,

--- a/packages/gitlab/src/components/widgets/PeopleCard/PeopleCard.tsx
+++ b/packages/gitlab/src/components/widgets/PeopleCard/PeopleCard.tsx
@@ -38,7 +38,7 @@ export const PeopleCard = ({}) => {
     const gitlab_instance = gitlabInstance();
     const codeowners_path = gitlabCodeOwnerPath();
 
-    const GitlabCIAPI = useApi(GitlabCIApiRef).build(gitlab_instance || '0');
+    const GitlabCIAPI = useApi(GitlabCIApiRef).build(gitlab_instance || 'gitlab.com');
     /* TODO: to change the below logic to get contributors data*/
     const { value, loading, error } = useAsync(async (): Promise<{
         contributors: PeopleCardEntityData[] | undefined;

--- a/packages/gitlab/src/components/widgets/PipelinesTable/PipelinesTable.tsx
+++ b/packages/gitlab/src/components/widgets/PipelinesTable/PipelinesTable.tsx
@@ -55,7 +55,7 @@ export const PipelinesTable = ({}) => {
     const project_slug = gitlabProjectSlug();
     const gitlab_instance = gitlabInstance();
 
-    const GitlabCIAPI = useApi(GitlabCIApiRef).build(gitlab_instance || '0');
+    const GitlabCIAPI = useApi(GitlabCIApiRef).build(gitlab_instance || 'gitlab.com');
 
     const { value, loading, error } = useAsync(async (): Promise<
         PipelineObject[]

--- a/packages/gitlab/src/components/widgets/ReleasesCard/ReleasesCard.tsx
+++ b/packages/gitlab/src/components/widgets/ReleasesCard/ReleasesCard.tsx
@@ -99,7 +99,7 @@ export const ReleasesCard = (props: ReleasesCardProps) => {
     const gitlab_instance = gitlabInstance();
 
     const GitlabCIAPI = useApi(GitlabCIApiRef).build(
-        gitlab_instance || '0'
+        gitlab_instance || 'gitlab.com'
     );
     /* TODO: to change the below logic to get contributors data*/
     const { value, loading, error } = useAsync(async (): Promise<{


### PR DESCRIPTION
## 🚨 Proposed changes

closes #118 
- processor and router have been changed to identify a GitLab instance by its hostname rather than a generated index number.
- refactored the processor conditional logic to decide if the entity needs to be processed (avoid looking up the host on entities that are excluded by their kind)
- tests have been updated

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
