### PR TITLE
chore(deps): bump backstage dependencies to version 1.15.0

### DIFF
--- a/packages/gitlab-backend/package.json
+++ b/packages/gitlab-backend/package.json
@@ -36,9 +36,9 @@
         "postpack": "backstage-cli package postpack"
     },
     "dependencies": {
-        "@backstage/backend-common": "^0.18.0",
-        "@backstage/config": "^1.0.6",
-        "@backstage/integration": "^1.4.2",
+        "@backstage/backend-common": "^0.19.0",
+        "@backstage/config": "^1.0.8",
+        "@backstage/integration": "^1.5.0",
         "@types/express": "*",
         "express": "^4.17.3",
         "express-promise-router": "^4.1.0",
@@ -47,10 +47,10 @@
         "yn": "^4.0.0"
     },
     "devDependencies": {
-        "@backstage/catalog-model": "^1.1.5",
-        "@backstage/cli": "^0.22.1",
-        "@backstage/plugin-catalog-common": "^1.0.10",
-        "@backstage/plugin-catalog-node": "^1.3.6",
+        "@backstage/catalog-model": "^1.4.0",
+        "@backstage/cli": "^0.22.8",
+        "@backstage/plugin-catalog-common": "^1.0.14",
+        "@backstage/plugin-catalog-node": "^1.3.7",
         "@types/supertest": "^2.0.12",
         "msw": "^1.0.0",
         "supertest": "^6.2.4"

--- a/packages/gitlab/package.json
+++ b/packages/gitlab/package.json
@@ -35,10 +35,10 @@
         "postpack": "backstage-cli package postpack"
     },
     "dependencies": {
-        "@backstage/core-components": "^0.13.0",
-        "@backstage/core-plugin-api": "^1.0.0",
-        "@backstage/plugin-catalog-react": "^1.2.3",
-        "@backstage/theme": "^0.2.14",
+        "@backstage/core-components": "^0.13.2",
+        "@backstage/core-plugin-api": "^1.5.2",
+        "@backstage/plugin-catalog-react": "^1.7.0",
+        "@backstage/theme": "^0.4.0",
         "@material-ui/core": "^4.12.2",
         "@material-ui/icons": "^4.9.1",
         "@material-ui/lab": "4.0.0-alpha.61",
@@ -53,11 +53,11 @@
         "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
     },
     "devDependencies": {
-        "@backstage/cli": "^0.22.3",
-        "@backstage/core-app-api": "^1.0.0",
-        "@backstage/dev-utils": "^1.0.8",
-        "@backstage/plugin-catalog-react": "^1.2.3",
-        "@backstage/test-utils": "^1.0.0",
+        "@backstage/cli": "^0.22.8",
+        "@backstage/core-app-api": "^1.8.1",
+        "@backstage/dev-utils": "^1.0.16",
+        "@backstage/plugin-catalog-react": "^1.7.0",
+        "@backstage/test-utils": "^1.4.0",
         "@commitlint/cli": "^17.0.0",
         "@commitlint/config-conventional": "^17.0.0",
         "@gitbeaker/rest": "^39.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -115,13 +115,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/abort-controller@npm:3.329.0, @aws-sdk/abort-controller@npm:^3.310.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/abort-controller@npm:3.329.0"
+"@aws-sdk/abort-controller@npm:3.357.0, @aws-sdk/abort-controller@npm:^3.347.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/abort-controller@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 37f65402b2599d19793a2fc9de18d61eed4663fd8b565f2782bc5ab5b9bcf0adc4600275dca3860d66dbcf1f347e5c506ca2cb41842e9f64d625cad9b4676fef
+  checksum: dee99ea164454db35f5a85deb0cec51b9d7065a1aa551c4ac7c0c8e2a538fd3827f9fd5812bd9576ce5dfd25a98fce1b26252d7a67d9ae864c65b5deb7f35a43
   languageName: node
   linkType: hard
 
@@ -134,491 +134,490 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-cognito-identity@npm:3.335.0":
-  version: 3.335.0
-  resolution: "@aws-sdk/client-cognito-identity@npm:3.335.0"
+"@aws-sdk/client-cognito-identity@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/client-cognito-identity@npm:3.358.0"
   dependencies:
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.335.0
-    "@aws-sdk/config-resolver": 3.329.0
-    "@aws-sdk/credential-provider-node": 3.335.0
-    "@aws-sdk/fetch-http-handler": 3.329.0
-    "@aws-sdk/hash-node": 3.329.0
-    "@aws-sdk/invalid-dependency": 3.329.0
-    "@aws-sdk/middleware-content-length": 3.329.0
-    "@aws-sdk/middleware-endpoint": 3.329.0
-    "@aws-sdk/middleware-host-header": 3.329.0
-    "@aws-sdk/middleware-logger": 3.329.0
-    "@aws-sdk/middleware-recursion-detection": 3.329.0
-    "@aws-sdk/middleware-retry": 3.329.0
-    "@aws-sdk/middleware-serde": 3.329.0
-    "@aws-sdk/middleware-signing": 3.329.0
-    "@aws-sdk/middleware-stack": 3.329.0
-    "@aws-sdk/middleware-user-agent": 3.332.0
-    "@aws-sdk/node-config-provider": 3.329.0
-    "@aws-sdk/node-http-handler": 3.329.0
-    "@aws-sdk/smithy-client": 3.329.0
-    "@aws-sdk/types": 3.329.0
-    "@aws-sdk/url-parser": 3.329.0
+    "@aws-sdk/client-sts": 3.358.0
+    "@aws-sdk/config-resolver": 3.357.0
+    "@aws-sdk/credential-provider-node": 3.358.0
+    "@aws-sdk/fetch-http-handler": 3.357.0
+    "@aws-sdk/hash-node": 3.357.0
+    "@aws-sdk/invalid-dependency": 3.357.0
+    "@aws-sdk/middleware-content-length": 3.357.0
+    "@aws-sdk/middleware-endpoint": 3.357.0
+    "@aws-sdk/middleware-host-header": 3.357.0
+    "@aws-sdk/middleware-logger": 3.357.0
+    "@aws-sdk/middleware-recursion-detection": 3.357.0
+    "@aws-sdk/middleware-retry": 3.357.0
+    "@aws-sdk/middleware-serde": 3.357.0
+    "@aws-sdk/middleware-signing": 3.357.0
+    "@aws-sdk/middleware-stack": 3.357.0
+    "@aws-sdk/middleware-user-agent": 3.357.0
+    "@aws-sdk/node-config-provider": 3.357.0
+    "@aws-sdk/node-http-handler": 3.357.0
+    "@aws-sdk/smithy-client": 3.358.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/url-parser": 3.357.0
     "@aws-sdk/util-base64": 3.310.0
     "@aws-sdk/util-body-length-browser": 3.310.0
     "@aws-sdk/util-body-length-node": 3.310.0
-    "@aws-sdk/util-defaults-mode-browser": 3.329.0
-    "@aws-sdk/util-defaults-mode-node": 3.329.0
-    "@aws-sdk/util-endpoints": 3.332.0
-    "@aws-sdk/util-retry": 3.329.0
-    "@aws-sdk/util-user-agent-browser": 3.329.0
-    "@aws-sdk/util-user-agent-node": 3.329.0
+    "@aws-sdk/util-defaults-mode-browser": 3.358.0
+    "@aws-sdk/util-defaults-mode-node": 3.358.0
+    "@aws-sdk/util-endpoints": 3.357.0
+    "@aws-sdk/util-retry": 3.357.0
+    "@aws-sdk/util-user-agent-browser": 3.357.0
+    "@aws-sdk/util-user-agent-node": 3.357.0
     "@aws-sdk/util-utf8": 3.310.0
     "@smithy/protocol-http": ^1.0.1
     "@smithy/types": ^1.0.0
     tslib: ^2.5.0
-  checksum: be9ad5933a2e24cc9e7f9859bec61c8e303b6c19bbf7e9bc0a7ee57dc10190404c2197ac0a98f1050be453db8b49cd9ba662a95faaf5c7dce4ed188fbb6d544a
+  checksum: cbc01289edd167250ca93f1b19970499be5a16b328bd8e8225fe7ca8d9774d0115632608130b9d099ba3ac230beb112f9e31f25bef13043424f7eac74b4a3d21
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-s3@npm:^3.310.0":
-  version: 3.335.0
-  resolution: "@aws-sdk/client-s3@npm:3.335.0"
+"@aws-sdk/client-s3@npm:^3.350.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/client-s3@npm:3.358.0"
   dependencies:
     "@aws-crypto/sha1-browser": 3.0.0
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.335.0
-    "@aws-sdk/config-resolver": 3.329.0
-    "@aws-sdk/credential-provider-node": 3.335.0
-    "@aws-sdk/eventstream-serde-browser": 3.329.0
-    "@aws-sdk/eventstream-serde-config-resolver": 3.329.0
-    "@aws-sdk/eventstream-serde-node": 3.329.0
-    "@aws-sdk/fetch-http-handler": 3.329.0
-    "@aws-sdk/hash-blob-browser": 3.329.0
-    "@aws-sdk/hash-node": 3.329.0
-    "@aws-sdk/hash-stream-node": 3.329.0
-    "@aws-sdk/invalid-dependency": 3.329.0
-    "@aws-sdk/md5-js": 3.329.0
-    "@aws-sdk/middleware-bucket-endpoint": 3.329.0
-    "@aws-sdk/middleware-content-length": 3.329.0
-    "@aws-sdk/middleware-endpoint": 3.329.0
-    "@aws-sdk/middleware-expect-continue": 3.329.0
-    "@aws-sdk/middleware-flexible-checksums": 3.331.0
-    "@aws-sdk/middleware-host-header": 3.329.0
-    "@aws-sdk/middleware-location-constraint": 3.329.0
-    "@aws-sdk/middleware-logger": 3.329.0
-    "@aws-sdk/middleware-recursion-detection": 3.329.0
-    "@aws-sdk/middleware-retry": 3.329.0
-    "@aws-sdk/middleware-sdk-s3": 3.329.0
-    "@aws-sdk/middleware-serde": 3.329.0
-    "@aws-sdk/middleware-signing": 3.329.0
-    "@aws-sdk/middleware-ssec": 3.329.0
-    "@aws-sdk/middleware-stack": 3.329.0
-    "@aws-sdk/middleware-user-agent": 3.332.0
-    "@aws-sdk/node-config-provider": 3.329.0
-    "@aws-sdk/node-http-handler": 3.329.0
-    "@aws-sdk/signature-v4-multi-region": 3.329.0
-    "@aws-sdk/smithy-client": 3.329.0
-    "@aws-sdk/types": 3.329.0
-    "@aws-sdk/url-parser": 3.329.0
+    "@aws-sdk/client-sts": 3.358.0
+    "@aws-sdk/config-resolver": 3.357.0
+    "@aws-sdk/credential-provider-node": 3.358.0
+    "@aws-sdk/eventstream-serde-browser": 3.357.0
+    "@aws-sdk/eventstream-serde-config-resolver": 3.357.0
+    "@aws-sdk/eventstream-serde-node": 3.357.0
+    "@aws-sdk/fetch-http-handler": 3.357.0
+    "@aws-sdk/hash-blob-browser": 3.357.0
+    "@aws-sdk/hash-node": 3.357.0
+    "@aws-sdk/hash-stream-node": 3.357.0
+    "@aws-sdk/invalid-dependency": 3.357.0
+    "@aws-sdk/md5-js": 3.357.0
+    "@aws-sdk/middleware-bucket-endpoint": 3.357.0
+    "@aws-sdk/middleware-content-length": 3.357.0
+    "@aws-sdk/middleware-endpoint": 3.357.0
+    "@aws-sdk/middleware-expect-continue": 3.357.0
+    "@aws-sdk/middleware-flexible-checksums": 3.357.0
+    "@aws-sdk/middleware-host-header": 3.357.0
+    "@aws-sdk/middleware-location-constraint": 3.357.0
+    "@aws-sdk/middleware-logger": 3.357.0
+    "@aws-sdk/middleware-recursion-detection": 3.357.0
+    "@aws-sdk/middleware-retry": 3.357.0
+    "@aws-sdk/middleware-sdk-s3": 3.357.0
+    "@aws-sdk/middleware-serde": 3.357.0
+    "@aws-sdk/middleware-signing": 3.357.0
+    "@aws-sdk/middleware-ssec": 3.357.0
+    "@aws-sdk/middleware-stack": 3.357.0
+    "@aws-sdk/middleware-user-agent": 3.357.0
+    "@aws-sdk/node-config-provider": 3.357.0
+    "@aws-sdk/node-http-handler": 3.357.0
+    "@aws-sdk/signature-v4-multi-region": 3.357.0
+    "@aws-sdk/smithy-client": 3.358.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/url-parser": 3.357.0
     "@aws-sdk/util-base64": 3.310.0
     "@aws-sdk/util-body-length-browser": 3.310.0
     "@aws-sdk/util-body-length-node": 3.310.0
-    "@aws-sdk/util-defaults-mode-browser": 3.329.0
-    "@aws-sdk/util-defaults-mode-node": 3.329.0
-    "@aws-sdk/util-endpoints": 3.332.0
-    "@aws-sdk/util-retry": 3.329.0
-    "@aws-sdk/util-stream-browser": 3.329.0
-    "@aws-sdk/util-stream-node": 3.331.0
-    "@aws-sdk/util-user-agent-browser": 3.329.0
-    "@aws-sdk/util-user-agent-node": 3.329.0
+    "@aws-sdk/util-defaults-mode-browser": 3.358.0
+    "@aws-sdk/util-defaults-mode-node": 3.358.0
+    "@aws-sdk/util-endpoints": 3.357.0
+    "@aws-sdk/util-retry": 3.357.0
+    "@aws-sdk/util-stream": 3.358.0
+    "@aws-sdk/util-user-agent-browser": 3.357.0
+    "@aws-sdk/util-user-agent-node": 3.357.0
     "@aws-sdk/util-utf8": 3.310.0
-    "@aws-sdk/util-waiter": 3.329.0
+    "@aws-sdk/util-waiter": 3.357.0
     "@aws-sdk/xml-builder": 3.310.0
     "@smithy/protocol-http": ^1.0.1
     "@smithy/types": ^1.0.0
-    fast-xml-parser: 4.1.2
+    fast-xml-parser: 4.2.4
     tslib: ^2.5.0
-  checksum: 65d0399a39f1d2f39c8286399df0ba453eda80c145034adf18890975e998668ac165c6f5039c3735638f8cabd622be947799a06baaff8114a7b6ebd7aa3e1675
+  checksum: 2e595d7e02c333b9830d04da8478f8819ae9280a84fc5f9032a023083f4c2f917d03255f0c7e38ca867ead9b06b2c72a354972e8fe8fafcb6fe3018557e9dbdd
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso-oidc@npm:3.335.0":
-  version: 3.335.0
-  resolution: "@aws-sdk/client-sso-oidc@npm:3.335.0"
+"@aws-sdk/client-sso-oidc@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/client-sso-oidc@npm:3.358.0"
   dependencies:
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/config-resolver": 3.329.0
-    "@aws-sdk/fetch-http-handler": 3.329.0
-    "@aws-sdk/hash-node": 3.329.0
-    "@aws-sdk/invalid-dependency": 3.329.0
-    "@aws-sdk/middleware-content-length": 3.329.0
-    "@aws-sdk/middleware-endpoint": 3.329.0
-    "@aws-sdk/middleware-host-header": 3.329.0
-    "@aws-sdk/middleware-logger": 3.329.0
-    "@aws-sdk/middleware-recursion-detection": 3.329.0
-    "@aws-sdk/middleware-retry": 3.329.0
-    "@aws-sdk/middleware-serde": 3.329.0
-    "@aws-sdk/middleware-stack": 3.329.0
-    "@aws-sdk/middleware-user-agent": 3.332.0
-    "@aws-sdk/node-config-provider": 3.329.0
-    "@aws-sdk/node-http-handler": 3.329.0
-    "@aws-sdk/smithy-client": 3.329.0
-    "@aws-sdk/types": 3.329.0
-    "@aws-sdk/url-parser": 3.329.0
+    "@aws-sdk/config-resolver": 3.357.0
+    "@aws-sdk/fetch-http-handler": 3.357.0
+    "@aws-sdk/hash-node": 3.357.0
+    "@aws-sdk/invalid-dependency": 3.357.0
+    "@aws-sdk/middleware-content-length": 3.357.0
+    "@aws-sdk/middleware-endpoint": 3.357.0
+    "@aws-sdk/middleware-host-header": 3.357.0
+    "@aws-sdk/middleware-logger": 3.357.0
+    "@aws-sdk/middleware-recursion-detection": 3.357.0
+    "@aws-sdk/middleware-retry": 3.357.0
+    "@aws-sdk/middleware-serde": 3.357.0
+    "@aws-sdk/middleware-stack": 3.357.0
+    "@aws-sdk/middleware-user-agent": 3.357.0
+    "@aws-sdk/node-config-provider": 3.357.0
+    "@aws-sdk/node-http-handler": 3.357.0
+    "@aws-sdk/smithy-client": 3.358.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/url-parser": 3.357.0
     "@aws-sdk/util-base64": 3.310.0
     "@aws-sdk/util-body-length-browser": 3.310.0
     "@aws-sdk/util-body-length-node": 3.310.0
-    "@aws-sdk/util-defaults-mode-browser": 3.329.0
-    "@aws-sdk/util-defaults-mode-node": 3.329.0
-    "@aws-sdk/util-endpoints": 3.332.0
-    "@aws-sdk/util-retry": 3.329.0
-    "@aws-sdk/util-user-agent-browser": 3.329.0
-    "@aws-sdk/util-user-agent-node": 3.329.0
+    "@aws-sdk/util-defaults-mode-browser": 3.358.0
+    "@aws-sdk/util-defaults-mode-node": 3.358.0
+    "@aws-sdk/util-endpoints": 3.357.0
+    "@aws-sdk/util-retry": 3.357.0
+    "@aws-sdk/util-user-agent-browser": 3.357.0
+    "@aws-sdk/util-user-agent-node": 3.357.0
     "@aws-sdk/util-utf8": 3.310.0
     "@smithy/protocol-http": ^1.0.1
     "@smithy/types": ^1.0.0
     tslib: ^2.5.0
-  checksum: 80510066a821fe2b58c684b29618e005f04fa7dc1276a50567b14eb75b837b618921d3033e6fe461b02b7dd1c48b69998cf30788bf4baad7ba8efece4336c605
+  checksum: 0453c965fef264f0d73789dbd7288813075e13d91d0992a3871e370f1fb1016c8d8bc0e8d1adef9edc658243047782d0438eac8fabc3e99661b8281858316fa5
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso@npm:3.335.0":
-  version: 3.335.0
-  resolution: "@aws-sdk/client-sso@npm:3.335.0"
+"@aws-sdk/client-sso@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/client-sso@npm:3.358.0"
   dependencies:
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/config-resolver": 3.329.0
-    "@aws-sdk/fetch-http-handler": 3.329.0
-    "@aws-sdk/hash-node": 3.329.0
-    "@aws-sdk/invalid-dependency": 3.329.0
-    "@aws-sdk/middleware-content-length": 3.329.0
-    "@aws-sdk/middleware-endpoint": 3.329.0
-    "@aws-sdk/middleware-host-header": 3.329.0
-    "@aws-sdk/middleware-logger": 3.329.0
-    "@aws-sdk/middleware-recursion-detection": 3.329.0
-    "@aws-sdk/middleware-retry": 3.329.0
-    "@aws-sdk/middleware-serde": 3.329.0
-    "@aws-sdk/middleware-stack": 3.329.0
-    "@aws-sdk/middleware-user-agent": 3.332.0
-    "@aws-sdk/node-config-provider": 3.329.0
-    "@aws-sdk/node-http-handler": 3.329.0
-    "@aws-sdk/smithy-client": 3.329.0
-    "@aws-sdk/types": 3.329.0
-    "@aws-sdk/url-parser": 3.329.0
+    "@aws-sdk/config-resolver": 3.357.0
+    "@aws-sdk/fetch-http-handler": 3.357.0
+    "@aws-sdk/hash-node": 3.357.0
+    "@aws-sdk/invalid-dependency": 3.357.0
+    "@aws-sdk/middleware-content-length": 3.357.0
+    "@aws-sdk/middleware-endpoint": 3.357.0
+    "@aws-sdk/middleware-host-header": 3.357.0
+    "@aws-sdk/middleware-logger": 3.357.0
+    "@aws-sdk/middleware-recursion-detection": 3.357.0
+    "@aws-sdk/middleware-retry": 3.357.0
+    "@aws-sdk/middleware-serde": 3.357.0
+    "@aws-sdk/middleware-stack": 3.357.0
+    "@aws-sdk/middleware-user-agent": 3.357.0
+    "@aws-sdk/node-config-provider": 3.357.0
+    "@aws-sdk/node-http-handler": 3.357.0
+    "@aws-sdk/smithy-client": 3.358.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/url-parser": 3.357.0
     "@aws-sdk/util-base64": 3.310.0
     "@aws-sdk/util-body-length-browser": 3.310.0
     "@aws-sdk/util-body-length-node": 3.310.0
-    "@aws-sdk/util-defaults-mode-browser": 3.329.0
-    "@aws-sdk/util-defaults-mode-node": 3.329.0
-    "@aws-sdk/util-endpoints": 3.332.0
-    "@aws-sdk/util-retry": 3.329.0
-    "@aws-sdk/util-user-agent-browser": 3.329.0
-    "@aws-sdk/util-user-agent-node": 3.329.0
+    "@aws-sdk/util-defaults-mode-browser": 3.358.0
+    "@aws-sdk/util-defaults-mode-node": 3.358.0
+    "@aws-sdk/util-endpoints": 3.357.0
+    "@aws-sdk/util-retry": 3.357.0
+    "@aws-sdk/util-user-agent-browser": 3.357.0
+    "@aws-sdk/util-user-agent-node": 3.357.0
     "@aws-sdk/util-utf8": 3.310.0
     "@smithy/protocol-http": ^1.0.1
     "@smithy/types": ^1.0.0
     tslib: ^2.5.0
-  checksum: c2cb8614c643331e35c1a0d46093dd0a7f9febf6bc260d53e1657b42247c18796b7a77c440d9ae00ab1c7071d851df71fe259a64add697f3001f188ad9902209
+  checksum: ee3371ad673ad69bbde5694396d7804a6e2c2a6144a095233e47eec325c17fc5f706909508fa9d7d93c2bef8a1a8849f99486f6c91b230d3fa0a9892135ff93b
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sts@npm:3.335.0, @aws-sdk/client-sts@npm:^3.310.0":
-  version: 3.335.0
-  resolution: "@aws-sdk/client-sts@npm:3.335.0"
+"@aws-sdk/client-sts@npm:3.358.0, @aws-sdk/client-sts@npm:^3.350.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/client-sts@npm:3.358.0"
   dependencies:
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/config-resolver": 3.329.0
-    "@aws-sdk/credential-provider-node": 3.335.0
-    "@aws-sdk/fetch-http-handler": 3.329.0
-    "@aws-sdk/hash-node": 3.329.0
-    "@aws-sdk/invalid-dependency": 3.329.0
-    "@aws-sdk/middleware-content-length": 3.329.0
-    "@aws-sdk/middleware-endpoint": 3.329.0
-    "@aws-sdk/middleware-host-header": 3.329.0
-    "@aws-sdk/middleware-logger": 3.329.0
-    "@aws-sdk/middleware-recursion-detection": 3.329.0
-    "@aws-sdk/middleware-retry": 3.329.0
-    "@aws-sdk/middleware-sdk-sts": 3.329.0
-    "@aws-sdk/middleware-serde": 3.329.0
-    "@aws-sdk/middleware-signing": 3.329.0
-    "@aws-sdk/middleware-stack": 3.329.0
-    "@aws-sdk/middleware-user-agent": 3.332.0
-    "@aws-sdk/node-config-provider": 3.329.0
-    "@aws-sdk/node-http-handler": 3.329.0
-    "@aws-sdk/smithy-client": 3.329.0
-    "@aws-sdk/types": 3.329.0
-    "@aws-sdk/url-parser": 3.329.0
+    "@aws-sdk/config-resolver": 3.357.0
+    "@aws-sdk/credential-provider-node": 3.358.0
+    "@aws-sdk/fetch-http-handler": 3.357.0
+    "@aws-sdk/hash-node": 3.357.0
+    "@aws-sdk/invalid-dependency": 3.357.0
+    "@aws-sdk/middleware-content-length": 3.357.0
+    "@aws-sdk/middleware-endpoint": 3.357.0
+    "@aws-sdk/middleware-host-header": 3.357.0
+    "@aws-sdk/middleware-logger": 3.357.0
+    "@aws-sdk/middleware-recursion-detection": 3.357.0
+    "@aws-sdk/middleware-retry": 3.357.0
+    "@aws-sdk/middleware-sdk-sts": 3.357.0
+    "@aws-sdk/middleware-serde": 3.357.0
+    "@aws-sdk/middleware-signing": 3.357.0
+    "@aws-sdk/middleware-stack": 3.357.0
+    "@aws-sdk/middleware-user-agent": 3.357.0
+    "@aws-sdk/node-config-provider": 3.357.0
+    "@aws-sdk/node-http-handler": 3.357.0
+    "@aws-sdk/smithy-client": 3.358.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/url-parser": 3.357.0
     "@aws-sdk/util-base64": 3.310.0
     "@aws-sdk/util-body-length-browser": 3.310.0
     "@aws-sdk/util-body-length-node": 3.310.0
-    "@aws-sdk/util-defaults-mode-browser": 3.329.0
-    "@aws-sdk/util-defaults-mode-node": 3.329.0
-    "@aws-sdk/util-endpoints": 3.332.0
-    "@aws-sdk/util-retry": 3.329.0
-    "@aws-sdk/util-user-agent-browser": 3.329.0
-    "@aws-sdk/util-user-agent-node": 3.329.0
+    "@aws-sdk/util-defaults-mode-browser": 3.358.0
+    "@aws-sdk/util-defaults-mode-node": 3.358.0
+    "@aws-sdk/util-endpoints": 3.357.0
+    "@aws-sdk/util-retry": 3.357.0
+    "@aws-sdk/util-user-agent-browser": 3.357.0
+    "@aws-sdk/util-user-agent-node": 3.357.0
     "@aws-sdk/util-utf8": 3.310.0
     "@smithy/protocol-http": ^1.0.1
     "@smithy/types": ^1.0.0
-    fast-xml-parser: 4.1.2
+    fast-xml-parser: 4.2.4
     tslib: ^2.5.0
-  checksum: f6ab10343a2878c867bb1c2d637261583e5700b4b9e1c5cf36d6c245b30c781f49756b7c2490c42eef5bb7838251780917dcfd03bd100fa51c0980d76fef38f4
+  checksum: 71da447c9c4f6832fd22350fde9c2aec0cedc74e4e2b1248367960c7c366244e1413a24938f3d418db543b627618278ea5119f58d54e1f10763cb6282dd35715
   languageName: node
   linkType: hard
 
-"@aws-sdk/config-resolver@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/config-resolver@npm:3.329.0"
+"@aws-sdk/config-resolver@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/config-resolver@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     "@aws-sdk/util-config-provider": 3.310.0
-    "@aws-sdk/util-middleware": 3.329.0
+    "@aws-sdk/util-middleware": 3.357.0
     tslib: ^2.5.0
-  checksum: c5838c0a60e955cda5fcd91361b168fe1bbedd997c9c4482383c98f2690149114f902d18a26ef3188b62734f2f3754cafed6283d4349d83eeb0d072b081f4ead
+  checksum: ea2d608b1a4257a8c70c12fec9bdc0ddc2ea8e2d61597053f8713677426aaf9ea2a2be2fdaea430f4b95c3d1c9830d5994db7c760a40cb066b3646fb14ff5339
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-cognito-identity@npm:3.335.0":
-  version: 3.335.0
-  resolution: "@aws-sdk/credential-provider-cognito-identity@npm:3.335.0"
+"@aws-sdk/credential-provider-cognito-identity@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/credential-provider-cognito-identity@npm:3.358.0"
   dependencies:
-    "@aws-sdk/client-cognito-identity": 3.335.0
-    "@aws-sdk/property-provider": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/client-cognito-identity": 3.358.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: f484d3eb680ee561414d8ada8dc4ab7e72138d2ad8eae913dcac94a47caaa87aa40aa4e06566f57d1a9ccf1d9c807ac3871cafa23b982f67f3c911da785320dc
+  checksum: 24c43c647382574fe8762578971a3e58ea3c79ca9bb08f5fe67d141d9c759af05a9b8ae4c3c9ffedbcfd4a49e813a688f88f9f4ffb6c9a62086f2d25e56d6099
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-env@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.329.0"
+"@aws-sdk/credential-provider-env@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.357.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 12cf04f542c722296adc4e6fbfe63334a60e7b1763b5e1ebfbaafcdcb332555d1f8cf9c855c249b056fb560a008957df4b7fd1551c04a7dbbebc6e3baad89eaa
+  checksum: a998ea7661cf1650d8c69f5a910bf921e6e13b8c9c1a7f4c07a6be9f18313cd8946dc67f2d97a3433e319d47fec84becf7913a8b80d97827de7a360b5d19b7f0
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-imds@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/credential-provider-imds@npm:3.329.0"
+"@aws-sdk/credential-provider-imds@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/credential-provider-imds@npm:3.357.0"
   dependencies:
-    "@aws-sdk/node-config-provider": 3.329.0
-    "@aws-sdk/property-provider": 3.329.0
-    "@aws-sdk/types": 3.329.0
-    "@aws-sdk/url-parser": 3.329.0
+    "@aws-sdk/node-config-provider": 3.357.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/url-parser": 3.357.0
     tslib: ^2.5.0
-  checksum: 853b42758e271f85b290aef5d5a2d717b3231016f1541a657408572c4a8fe7f2a209450bc1133715007b895d3c74d065b90a229e31351493bacf368720676471
+  checksum: 96c96d44471aed248a4d4f91a3b5c850fcf02a4cc2074a440ec6da7da56f85ee0a0b4f14e479d204d2228cb3737ecdf637d8b046ab8cc7d038d19a7dae57b0bc
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-ini@npm:3.335.0":
-  version: 3.335.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.335.0"
+"@aws-sdk/credential-provider-ini@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.358.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": 3.329.0
-    "@aws-sdk/credential-provider-imds": 3.329.0
-    "@aws-sdk/credential-provider-process": 3.329.0
-    "@aws-sdk/credential-provider-sso": 3.335.0
-    "@aws-sdk/credential-provider-web-identity": 3.329.0
-    "@aws-sdk/property-provider": 3.329.0
-    "@aws-sdk/shared-ini-file-loader": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/credential-provider-env": 3.357.0
+    "@aws-sdk/credential-provider-imds": 3.357.0
+    "@aws-sdk/credential-provider-process": 3.357.0
+    "@aws-sdk/credential-provider-sso": 3.358.0
+    "@aws-sdk/credential-provider-web-identity": 3.357.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/shared-ini-file-loader": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 79414e4c4bbdd5775187f5a2b8975824d97718b2528ae5daf073f388994cdb6d5667c41f7578e84da6df73769321d3566386b113a463aa2ddaf36ccb0d7e8cab
+  checksum: f7637e518ce98654c4c06d3cf01f35d7cdc22893b8a37fc522479b7324ba63f7362ea0b60dbb142573fa1148fa0b900791ad8a8361227170055122fec72e9b78
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-node@npm:3.335.0, @aws-sdk/credential-provider-node@npm:^3.310.0":
-  version: 3.335.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.335.0"
+"@aws-sdk/credential-provider-node@npm:3.358.0, @aws-sdk/credential-provider-node@npm:^3.350.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.358.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": 3.329.0
-    "@aws-sdk/credential-provider-imds": 3.329.0
-    "@aws-sdk/credential-provider-ini": 3.335.0
-    "@aws-sdk/credential-provider-process": 3.329.0
-    "@aws-sdk/credential-provider-sso": 3.335.0
-    "@aws-sdk/credential-provider-web-identity": 3.329.0
-    "@aws-sdk/property-provider": 3.329.0
-    "@aws-sdk/shared-ini-file-loader": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/credential-provider-env": 3.357.0
+    "@aws-sdk/credential-provider-imds": 3.357.0
+    "@aws-sdk/credential-provider-ini": 3.358.0
+    "@aws-sdk/credential-provider-process": 3.357.0
+    "@aws-sdk/credential-provider-sso": 3.358.0
+    "@aws-sdk/credential-provider-web-identity": 3.357.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/shared-ini-file-loader": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 8c1b724eff8ab120a343543914f56bd13625c4aae1a7a69b5d29852093485917435aec91f6614491b268477ba6d05963a4dea9a4709523fd2f8d061f46f2358c
+  checksum: 5459a864680bb377a43625ce7af915bd9298251119df693a73324adcd2b3753aed20460a9c6cc146b796db00970d2bc6f3887c0ade217568d0e5dba043f7b21d
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-process@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.329.0"
+"@aws-sdk/credential-provider-process@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.357.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.329.0
-    "@aws-sdk/shared-ini-file-loader": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/shared-ini-file-loader": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 198fb80efab5a29ea0d72e96f0f45adbe3532b56deca045c7cc4089bf7a5388f73e340df135525f4392d942e3a1c516d3cd692d4de7f4d4e6ef9241d7470ee7a
+  checksum: 753f6d9ccd40cf4422aae8b5512c9f24fbded6e7e631c68673828214294c507e1322ac2e455fb43458cc97f3185681f555fdbb220ff2cf0a6b3fcfca366fddae
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-sso@npm:3.335.0":
-  version: 3.335.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.335.0"
+"@aws-sdk/credential-provider-sso@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.358.0"
   dependencies:
-    "@aws-sdk/client-sso": 3.335.0
-    "@aws-sdk/property-provider": 3.329.0
-    "@aws-sdk/shared-ini-file-loader": 3.329.0
-    "@aws-sdk/token-providers": 3.335.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/client-sso": 3.358.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/shared-ini-file-loader": 3.357.0
+    "@aws-sdk/token-providers": 3.358.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: f8317ff846d3a7beda11627266e49ece43f2c1dff92a7c96da6c5b9f1f1e3108b98d8b7b5cddb0f43ffb5cef74683bc3f68eb708cd727e0f4992c6666b58343e
+  checksum: a817f23af990765b511fb63889aa46beb624af7b95ffdef05a98e31b68eb3f8bfd8c7831c7eb92613e90d729e392cc5e6d055181785193c7fad75d65f239b72c
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-web-identity@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.329.0"
+"@aws-sdk/credential-provider-web-identity@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.357.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: fcbc21976d471999285904cb4924b49d85d846ecc3495a2fc6a5e8ff611765da1fdfd98f5cc828af29e43a0e087c3f49dae0186ef8e43de4afd07bec43c6fc69
+  checksum: 75625393c7a54169666eccc713eb7aa1c5d931680034c3785d4fadf70d281ff4e27132af0a6ae074c5d96f797bfe86e1c4bfd4a53865692c8bff1bf67d66271c
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-providers@npm:^3.310.0":
-  version: 3.335.0
-  resolution: "@aws-sdk/credential-providers@npm:3.335.0"
+"@aws-sdk/credential-providers@npm:^3.350.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/credential-providers@npm:3.358.0"
   dependencies:
-    "@aws-sdk/client-cognito-identity": 3.335.0
-    "@aws-sdk/client-sso": 3.335.0
-    "@aws-sdk/client-sts": 3.335.0
-    "@aws-sdk/credential-provider-cognito-identity": 3.335.0
-    "@aws-sdk/credential-provider-env": 3.329.0
-    "@aws-sdk/credential-provider-imds": 3.329.0
-    "@aws-sdk/credential-provider-ini": 3.335.0
-    "@aws-sdk/credential-provider-node": 3.335.0
-    "@aws-sdk/credential-provider-process": 3.329.0
-    "@aws-sdk/credential-provider-sso": 3.335.0
-    "@aws-sdk/credential-provider-web-identity": 3.329.0
-    "@aws-sdk/property-provider": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/client-cognito-identity": 3.358.0
+    "@aws-sdk/client-sso": 3.358.0
+    "@aws-sdk/client-sts": 3.358.0
+    "@aws-sdk/credential-provider-cognito-identity": 3.358.0
+    "@aws-sdk/credential-provider-env": 3.357.0
+    "@aws-sdk/credential-provider-imds": 3.357.0
+    "@aws-sdk/credential-provider-ini": 3.358.0
+    "@aws-sdk/credential-provider-node": 3.358.0
+    "@aws-sdk/credential-provider-process": 3.357.0
+    "@aws-sdk/credential-provider-sso": 3.358.0
+    "@aws-sdk/credential-provider-web-identity": 3.357.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: c82923a923f6433b61b45beff33fc34ae87be172a3941ff85d692d839e8fad64b4f68032ad7c4ec6a5fd3bed5f34ab5fef069788c1fc48f99c75f94c1b8c407f
+  checksum: 0e8acaea94d5b0933ba331fbe0155cc5e247c8e2626c1f1c7ff5a42ad8b22f2d6baa82730d68aa2d8077f19ced058db777f1a0af103f06685f13b6eb086d8f15
   languageName: node
   linkType: hard
 
-"@aws-sdk/eventstream-codec@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/eventstream-codec@npm:3.329.0"
+"@aws-sdk/eventstream-codec@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/eventstream-codec@npm:3.357.0"
   dependencies:
     "@aws-crypto/crc32": 3.0.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     "@aws-sdk/util-hex-encoding": 3.310.0
     tslib: ^2.5.0
-  checksum: c57070e439b8a9009cb11f47b51f233b2fc6cff785a6e8ab869e8d7b299dd358fd14053f943ef14fbf1d4affd7e23de8f976ece09d4b180ca0a053e74724d35b
+  checksum: df05de4c42d47f46e3808030f0f190747350218d9a3733958810de2a43e3a4be8458cde27c1f9c7467b0ea65a5d668aa3c72418b3fdf66295c4a91ba07b2ea0e
   languageName: node
   linkType: hard
 
-"@aws-sdk/eventstream-serde-browser@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/eventstream-serde-browser@npm:3.329.0"
+"@aws-sdk/eventstream-serde-browser@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/eventstream-serde-browser@npm:3.357.0"
   dependencies:
-    "@aws-sdk/eventstream-serde-universal": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/eventstream-serde-universal": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 07d318f9bf41427947dfe885f1fe4b1f2a08934fd43db4c44fd941baf92bb989e8b9e380597e0b7834e3190e697dd72ab2ba5c8fff3437ab84efae3706a5e217
+  checksum: fbd2e71d6ce773f2667adc3d930acc791e83be814274ebd4d019dcad1b818b7625de7b30ab14371a9bdac031e0285d1cc6a1e835dad9801a5888a11e50be134c
   languageName: node
   linkType: hard
 
-"@aws-sdk/eventstream-serde-config-resolver@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/eventstream-serde-config-resolver@npm:3.329.0"
+"@aws-sdk/eventstream-serde-config-resolver@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/eventstream-serde-config-resolver@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 51a4c94beffcf74f956f1750a99788fdfd15d1dcddbc5ab2b5c8d0a089a430cad16b2b27515aac84c4dc0ff304a8d69212a2af411e921eb3fd59f49ed3ef7b48
+  checksum: 6e61b9e8191eb9e2c2973701082aaa58f3b57268116ab8d1dab02d24145baa8535443ae749028310fdd80d7347973a633982fb05b38c9cbf79fa2586b5f29dd9
   languageName: node
   linkType: hard
 
-"@aws-sdk/eventstream-serde-node@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/eventstream-serde-node@npm:3.329.0"
+"@aws-sdk/eventstream-serde-node@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/eventstream-serde-node@npm:3.357.0"
   dependencies:
-    "@aws-sdk/eventstream-serde-universal": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/eventstream-serde-universal": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 398fd78b194eef3a95f84d056d5d1690e0342a3f643aae2ac40465cefa81ff21dcd299d93d53ffbdf22c49807a932c6798d17a913f466f3f7ed4c9b23ea136fa
+  checksum: 1edbecd5c49322ac13e481155751912ec25d078635b50f7c0af40de916e98206a6f668847c73a1d7874526e8ec606a923e610445976a9b29c09ab8221f5a3700
   languageName: node
   linkType: hard
 
-"@aws-sdk/eventstream-serde-universal@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/eventstream-serde-universal@npm:3.329.0"
+"@aws-sdk/eventstream-serde-universal@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/eventstream-serde-universal@npm:3.357.0"
   dependencies:
-    "@aws-sdk/eventstream-codec": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/eventstream-codec": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: ffdaa375d9a97079380514849b4f561ba24955da754f5bfebc9406dc43fe93674c0275278d27b2568313056a04be3de6f1783f7a471b501e84736e1f2c95155a
+  checksum: a733d008599191941f258216581a2260c0acbd223add882c47fc3bd6b912a39977ac1146b151ef78bb01de5adcf3d49bf4365dbe82162538f34b681e3d8da966
   languageName: node
   linkType: hard
 
-"@aws-sdk/fetch-http-handler@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/fetch-http-handler@npm:3.329.0"
+"@aws-sdk/fetch-http-handler@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/fetch-http-handler@npm:3.357.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.329.0
-    "@aws-sdk/querystring-builder": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/querystring-builder": 3.357.0
+    "@aws-sdk/types": 3.357.0
     "@aws-sdk/util-base64": 3.310.0
     tslib: ^2.5.0
-  checksum: 85795cd97f1538ed4d713b370377667f18bf3ead1326815452b8636e6ae07af3726f75bb95f2ad31d6fa06eb802903344f3413724ca4e593fbe8a05c533c8e52
+  checksum: c72a5e1bca33df01d2b4f827cf45a10c22fcc8d46b2728bfb17f5d1ffc4f6157855668082848969c3bd9930e871767e123d78d4a56e4b989ead97fe544ffb327
   languageName: node
   linkType: hard
 
-"@aws-sdk/hash-blob-browser@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/hash-blob-browser@npm:3.329.0"
+"@aws-sdk/hash-blob-browser@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/hash-blob-browser@npm:3.357.0"
   dependencies:
     "@aws-sdk/chunked-blob-reader": 3.310.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 9b8e0a5ae442f0cce372bf79a0e634c6b99eb4fa39cea91bda437de51e4da4fbe288e0229c04f778d865b9281e2e93fbfe0b269a492ecd7285e9f84f3816cb24
+  checksum: 3bdc8b401b19521dcb8365a1e33d88f005af6e7c930c83eb45460eafcc4639b9a3d54d44a97ad3941f795d420a8fa3b7cb3b3b25bb4a79d16257031cd894e40b
   languageName: node
   linkType: hard
 
-"@aws-sdk/hash-node@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/hash-node@npm:3.329.0"
+"@aws-sdk/hash-node@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/hash-node@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     "@aws-sdk/util-buffer-from": 3.310.0
     "@aws-sdk/util-utf8": 3.310.0
     tslib: ^2.5.0
-  checksum: 19f505bc9ef34b15277acb13cfed9f06efc6a4d648df45aed5eb12c0c3566a6338e00bf126081fb5429149c69ba99b9120aebe5940eb91ac7a6686a5f0c9cabf
+  checksum: 295fbfd2099a393537067a313619d41b2efafae690f252e501c44e75ad4149df67c5e08786cb75f4e3e34b2f16871c4d1603ff8f91dcc9975137bf868e19a2cc
   languageName: node
   linkType: hard
 
-"@aws-sdk/hash-stream-node@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/hash-stream-node@npm:3.329.0"
+"@aws-sdk/hash-stream-node@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/hash-stream-node@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     "@aws-sdk/util-utf8": 3.310.0
     tslib: ^2.5.0
-  checksum: 3901b6fa62e9e09a21c16c13f929a401338366c12a0ba695b830a5195859740cc6853cb22cc01c164fbfb9db817dabac2f260033cbb027f506abaae7a499f2c5
+  checksum: 6599d19353c1aaeeac49b1f5aee37fa4c0ff00c23518c782a51df375f661fa7c068e2d3a4ebfdd7fc94ceee0419054c7f0150a0c8754fca85c9e67f5dbfe36b4
   languageName: node
   linkType: hard
 
-"@aws-sdk/invalid-dependency@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/invalid-dependency@npm:3.329.0"
+"@aws-sdk/invalid-dependency@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/invalid-dependency@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 0e5f122ab2529386f7531bdf1494968264b6e2addd89e484bb3f28ad3bd8d438d381923e61cfd4ea3dfe930982d484541d9b8c562a19de90fec06791d6bcc586
+  checksum: 203148201ea0957350231cf8c1821e6e11573dfb36c5648f30bf2a89955a754500d228f93a63a08299881be151301cf9fe8417353653fe582d8f4f82d28fc4d1
   languageName: node
   linkType: hard
 
@@ -631,355 +630,367 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/md5-js@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/md5-js@npm:3.329.0"
+"@aws-sdk/md5-js@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/md5-js@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     "@aws-sdk/util-utf8": 3.310.0
     tslib: ^2.5.0
-  checksum: 3471b9c5e62a4c37c609a6575ea521028cd2852bbaf1a55e8d077ed0c4d90c4339e6c6a3015553e9549d1e519ade4d68acc98571a1fa9e880d66c907cfd12977
+  checksum: 7ca7ea50ccbbb22a1eadccdafe6686260273638616e283867d0b52701b0486ca81ad3c134b56c14428bc44ed5aaa1033c3467aa7fb345d413ea178ee26e90ce2
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-bucket-endpoint@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.329.0"
+"@aws-sdk/middleware-bucket-endpoint@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.357.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/types": 3.357.0
     "@aws-sdk/util-arn-parser": 3.310.0
     "@aws-sdk/util-config-provider": 3.310.0
     tslib: ^2.5.0
-  checksum: bda4e039ee9655d528e6416005bb4efa13e9dcd16a7c16d1693ed7970702bce3c2ff8ea6204a3c090c9881cf7a6ccf2385f44ac9fcc9b8d8addf6a27fa93d56b
+  checksum: d0a673d3242db3c88162ac2cdc571bbad7951837e95d8ed630ef2099d11640199003e933ef688f13aed8948e2493f5f77680fdf9662e2af7731a7a6d103631b4
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-content-length@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/middleware-content-length@npm:3.329.0"
+"@aws-sdk/middleware-content-length@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-content-length@npm:3.357.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: ffc2f7d2c7b2c7398d54b118c7392816f8e24ac4b350794f0c501a9ca82c67d4b6f90d9442f6ffa71b3e1f75da20b5274390b0a18d8f4adcedf5893251023588
+  checksum: 308f5d7f1fa2e42c3bf3619d42cfa85ad47e1b219428e01ad21ad1ebc60ac1b416aabec1868f3ea30a81215cf3386c1dadb3b98e5e66280a092da3fa487774cc
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-endpoint@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/middleware-endpoint@npm:3.329.0"
+"@aws-sdk/middleware-endpoint@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-endpoint@npm:3.357.0"
   dependencies:
-    "@aws-sdk/middleware-serde": 3.329.0
-    "@aws-sdk/types": 3.329.0
-    "@aws-sdk/url-parser": 3.329.0
-    "@aws-sdk/util-middleware": 3.329.0
+    "@aws-sdk/middleware-serde": 3.357.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/url-parser": 3.357.0
+    "@aws-sdk/util-middleware": 3.357.0
     tslib: ^2.5.0
-  checksum: ed662d778a4ab7b05ee4fba607d6b72e798ee969752fabe2141546a184a71f2daf206a2b8300fa68de0339ebc2646fb8fdf9bf22ebf9cf68495518465c1f1bcc
+  checksum: 2085f37d237e33378ecce44703f9dca5b9f66b36b4bbbd4bb39e726ebce745d07ca948b1d6f9a2f832d75b4e67ec3254d89d26ded4596c5cf29aad827a0fa906
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-expect-continue@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/middleware-expect-continue@npm:3.329.0"
+"@aws-sdk/middleware-expect-continue@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-expect-continue@npm:3.357.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 462dd314e80ce17e5975e4b4ce162d41a44691845dfff6b6ae7bd0eb449402bd2d1f93ab577513faf089c9fb193b9a79ccd1ccfb1eb917576e42c2618e4d2ef9
+  checksum: 3696affb277af3ae0c0e63b4fa0847dbb9eaab9980cfcb7cb8c901eaa5e6c456b6b9c1bad234a573503bb916ee0dc59d077b1f443a23647b7736c443acce5b99
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-flexible-checksums@npm:3.331.0":
-  version: 3.331.0
-  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.331.0"
+"@aws-sdk/middleware-flexible-checksums@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.357.0"
   dependencies:
     "@aws-crypto/crc32": 3.0.0
     "@aws-crypto/crc32c": 3.0.0
     "@aws-sdk/is-array-buffer": 3.310.0
-    "@aws-sdk/protocol-http": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/types": 3.357.0
     "@aws-sdk/util-utf8": 3.310.0
     tslib: ^2.5.0
-  checksum: 3186f5902afb4bd1a9d9aab9b6f0c70869734981ef721989a778cd5b3a5d1feb6915234aceaa044b1435e3100115dbafa7034494b65f88aa41bc738410c9d089
+  checksum: f8cbd80c67645113e5b37b34092f8790c43616b5524d8a2995946b268dc1d8a473be059dbcfcd281de8abd1fbc6e6d97ba4776badde34eb1aa0412dca4265fa1
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-host-header@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/middleware-host-header@npm:3.329.0"
+"@aws-sdk/middleware-host-header@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.357.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: a83d44c24fedf605cfc1b715f5529fc5c424c11ef77a29fa483e390d379a0ca0a4839249d64e71a8a3f096a2ed97ddf95fc8726149bbb9343f50d6522f0ed46b
+  checksum: e8471d0ca23ca598a042704877069a81576c2fb743c37818cc09c9383431ecb7e2f32f4bdf22094011bec3ece3e8523f2a3a99b8f8b04e4cca0c871d4d7a8194
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-location-constraint@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/middleware-location-constraint@npm:3.329.0"
+"@aws-sdk/middleware-location-constraint@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-location-constraint@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 04565ae85637cec8c2d0fc574479e36cc953c86e9ec22e4ebc22d52b832b2d4e50b71750f72d4ddcabf1ce820ce8edccf9efb5fadcf292e9ad842289d16999c9
+  checksum: ea93c9df62ff40b484fbf7d00183cc455682665cff0cb4c115abfbf4948503f812bb0450aa29d1d3110591f79ef52a433dbc49fcd45698efc70d9e13955869c8
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-logger@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/middleware-logger@npm:3.329.0"
+"@aws-sdk/middleware-logger@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 85031d5d562ae34a550c9ce355cce2e322924dfbb6140e255444056a6f97ab3a98db9d9854572c0d1cf2d73e0e086320a6324cabedac66e975007f1140148c49
+  checksum: 0ee86f855ccebb31205b5f86e7b2baba71e2127d02d55ff630757d198ae40766458835ae247cae43a33030b6ba2b36f676ae8fc3935601d321bf6cd9515a1b2a
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-recursion-detection@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.329.0"
+"@aws-sdk/middleware-recursion-detection@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.357.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 921683327a3047d9fa8c1c027bee44330ae769a45bdd205a7a5d1a262fde09c404c574a60497e87987f01670daf56b2e0084fdacded87270917f04e99ac437a4
+  checksum: 33625801a66eed9dc68ea0ccb4689b5a26ae3e5aa39d790c241f534aa8c1da9650a7fd607333e24f0aa59d9d8c9c57de16e31ff5d100298edb0238aec79b5bb1
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-retry@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/middleware-retry@npm:3.329.0"
+"@aws-sdk/middleware-retry@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-retry@npm:3.357.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.329.0
-    "@aws-sdk/service-error-classification": 3.329.0
-    "@aws-sdk/types": 3.329.0
-    "@aws-sdk/util-middleware": 3.329.0
-    "@aws-sdk/util-retry": 3.329.0
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/service-error-classification": 3.357.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/util-middleware": 3.357.0
+    "@aws-sdk/util-retry": 3.357.0
     tslib: ^2.5.0
     uuid: ^8.3.2
-  checksum: 1c3eed0037a06c5201a8c102c1d5b946571a8085bde0ccc9fafb3c62343414383ee94883c07e7b2e4e870852a7a54798e1cbaeda17062d7a4b7178f6355f3119
+  checksum: bf9d0143af03431bb28c24d055780711774ef312c710ae4b58d846924a7d35571a7c2bd4e5a7e1ac219b791ba0af259df06ba139df478a2e7a53004e7712ca47
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-s3@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.329.0"
+"@aws-sdk/middleware-sdk-s3@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.357.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/types": 3.357.0
     "@aws-sdk/util-arn-parser": 3.310.0
     tslib: ^2.5.0
-  checksum: 4de1fc7b4ac6b01c3e65ee8e25151b73d3f78d5ac3949d799b10252a42a8b55bb00242822757bbc790dde545745fb8d2f83feb09442eec83846c431d98aeab27
+  checksum: 18acbd6ea79fa907deeeb6e2cbedc7141c0201f947f5f6faa1b3657f65cbc769db324634dab911a404bf00be9e4cf3259e4b2ca0e0209e7986fc9b7a016152ca
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-sts@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.329.0"
+"@aws-sdk/middleware-sdk-sts@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.357.0"
   dependencies:
-    "@aws-sdk/middleware-signing": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/middleware-signing": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 0c5450726c546f6f4b3de50e1a9a1757ca267f6fece5ef3dcf1560955eea885d0476debbce0d3f67290db77e7b894a386f5822b7d5bde8d9bcfea5af94735918
+  checksum: 138a7f8a397529a05c1316bc0c39339678ed6025b9a356126129136e078cfa48b79ead194f5354cb7089cedd787b1a9927e6fb9fd01bd4f42bed78df02204c6e
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-serde@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/middleware-serde@npm:3.329.0"
+"@aws-sdk/middleware-serde@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-serde@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 29b72c582f6c783396e6e7a5a9bd6416ceebb18a15b55187267cdb3e2a6f18e2395d2aafdbeedeedce8c014b0d7fbd40d151accc1e409fe8741cee346b0c9ce1
+  checksum: 259176f253efc144130494f9dcaafdf5ff0a1d60158619ef300146775ab68622289908a15d1131ee8c7f92235a6ce40df4c80fdc930a8e45eb2635a6e241ac9e
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-signing@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/middleware-signing@npm:3.329.0"
+"@aws-sdk/middleware-signing@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-signing@npm:3.357.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.329.0
-    "@aws-sdk/protocol-http": 3.329.0
-    "@aws-sdk/signature-v4": 3.329.0
-    "@aws-sdk/types": 3.329.0
-    "@aws-sdk/util-middleware": 3.329.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/signature-v4": 3.357.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/util-middleware": 3.357.0
     tslib: ^2.5.0
-  checksum: 6dad12d4e3cfad3dd508ad2177da3ec5d54015d606c670999659c21dfaaf41b1cbb52c92704a9ecf0f82e322ae9f62a0639c2e3cf1b201c08d78b99638abdd1c
+  checksum: 416c8472606f6139bcf548d3c45582b0cfadf0da114c63a90fc26aa0301ce1743e5ce93517dfccb1e8756f4c9925c3b2e485b7a1a7853c418061c827be01a2c0
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-ssec@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/middleware-ssec@npm:3.329.0"
+"@aws-sdk/middleware-ssec@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-ssec@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 819623a8a3a8d3518fcc194025a470a06d0b6889cb88f165a7f49aea6b1e4396effe448ac94b8a27928aca8752502960d6899a5597f293f0542ee9d0e5a872da
+  checksum: cf0f7cc3eb9b9a7a1c77a0885bbe8f0eb62a3f57b3949e5c53e80c3925a3328d4fdd8dce238d3fb69813d577e77281a1e2e8844ec39408f41030987e8a2e9224
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-stack@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/middleware-stack@npm:3.329.0"
+"@aws-sdk/middleware-stack@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-stack@npm:3.357.0"
   dependencies:
     tslib: ^2.5.0
-  checksum: 34b2ac02f8bd21a6803064de8059a866aa776c8a7962d40e11d072801291b9f5e78daac5adf91931ca1d19b11e2e972467c6b9679bf7c049b5f63ce50eb214d9
+  checksum: bb5507ee38e60b8a8fbf3fc7215be710d379c54d7132c78005892563b1e3e0169c00187ec482808a7b68edcefb7a2a420a47f7813dc627f2747703cfee9b99e0
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-user-agent@npm:3.332.0":
-  version: 3.332.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.332.0"
+"@aws-sdk/middleware-user-agent@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.357.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.329.0
-    "@aws-sdk/types": 3.329.0
-    "@aws-sdk/util-endpoints": 3.332.0
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/util-endpoints": 3.357.0
     tslib: ^2.5.0
-  checksum: 82041292082689828f1356fa102db3c8b19c84c65870f251b6ae57dd5fdcdb2c491e6a8fb6f709cae081c3ffc8c8bd19d52ce27f608ea66c0a8c615faa520dd5
+  checksum: e80a6fce7974f79769349ee9c2fc6744a18d1998e7e66b3eb24196390a5605837cf5fd75b4e9636566353d5fb26c840628ea8e451045af66c0112469ce20debb
   languageName: node
   linkType: hard
 
-"@aws-sdk/node-config-provider@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/node-config-provider@npm:3.329.0"
+"@aws-sdk/node-config-provider@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/node-config-provider@npm:3.357.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.329.0
-    "@aws-sdk/shared-ini-file-loader": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/shared-ini-file-loader": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 25178c8857f48931079b204e2c904f7960edbae2a34bb6ccb8f27991d807a61e05dcf42cad4bb56cb98c5c12aedebea58a840b3bea30a06c174cb6758b03e2d5
+  checksum: 39784541ffdabc6298c42f3e4c308c75e92636b1228f6338d9820d2a6ee6ebb77dacd92e42f739004db6299024d85e80c0191f8c49045f1f00451aedc2136786
   languageName: node
   linkType: hard
 
-"@aws-sdk/node-http-handler@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/node-http-handler@npm:3.329.0"
+"@aws-sdk/node-http-handler@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/node-http-handler@npm:3.357.0"
   dependencies:
-    "@aws-sdk/abort-controller": 3.329.0
-    "@aws-sdk/protocol-http": 3.329.0
-    "@aws-sdk/querystring-builder": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/abort-controller": 3.357.0
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/querystring-builder": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 0560640be504cbe1f4d5098cdef917085472f476487d2fcd5225ab67063dca53718a30d48cb255790d327356f8b544bba491175dd2d6c9b8319327f5204909ae
+  checksum: 535fe5699b1013f84c47fdefe99659c9eebda6bdac09a83d486438a3c4a3c2b5985a6e5f9184ba49624615d5886013c1c6bfe5e7bd4063f31b95665797c98fb6
   languageName: node
   linkType: hard
 
-"@aws-sdk/property-provider@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/property-provider@npm:3.329.0"
+"@aws-sdk/property-provider@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/property-provider@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 17c8cb7d28b55ff9ba1f81da87dff42815919c6458eec422d1a45d7d809f7ee531e7b5daeb2bb63eab569eb12c0d6bce270a66e060c8c19d841d1894211f6dfd
+  checksum: 311c00ef9c20810ea18b6772d3f37853469453fd31b1b41d841ecfd6a7f34f2ba2189df954bc094c5ff764bd75bc39ce003f208260334b40b8394f8f2665cd93
   languageName: node
   linkType: hard
 
-"@aws-sdk/protocol-http@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/protocol-http@npm:3.329.0"
+"@aws-sdk/protocol-http@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/protocol-http@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 6b88be86283c67fd6fc9c3f8260c02e916f6f9b4c2a554a261809d6e48ef3dbae0a6c02ecde90cbfcd77f8066dbb37c2263e22fbeb20c2a5ac19e3ffc2582b67
+  checksum: 2abc03c76b729b98b37a489ee6592d8620e02c17584c304e91161194d7d4273bf9f8a7e330d52be2f8f8c787db63db99d7865494fb85f07327ffc54b99712b07
   languageName: node
   linkType: hard
 
-"@aws-sdk/querystring-builder@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/querystring-builder@npm:3.329.0"
+"@aws-sdk/querystring-builder@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/querystring-builder@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     "@aws-sdk/util-uri-escape": 3.310.0
     tslib: ^2.5.0
-  checksum: 188a3e6ee142af8ec8fa6563db831e70069a4f94487f25b02da608fe569d881c4b696abff8bbf98ff154107ed4b57170f1b6633ec55a7ddbffabb3cd745c243f
+  checksum: f3b8b10ff997eade4ec632be937afdd6d44b7eb15b9ff64d21d31ba6c9f64f90263de2ba904660faa20dbb2b73c3a0193744b78ba2b42a757e28fd41be11d63e
   languageName: node
   linkType: hard
 
-"@aws-sdk/querystring-parser@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/querystring-parser@npm:3.329.0"
+"@aws-sdk/querystring-parser@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/querystring-parser@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: eebb633db0bf9d9a3854ab2f83526468b430f57fb8b5cd2c737683facf717d96876acb4a837e17235458e728ebf375a26321ea6dd4dc07f5eb9eaa6e4efad1b5
+  checksum: 57097dda2499991efd00c3773c8ecd5d75d0e0d9a5106e3e8f4649f008d47eb87b01b067ceaee1ae73202a3cdf62458b713fa92cdf309e7d73bdcaffed54b4c7
   languageName: node
   linkType: hard
 
-"@aws-sdk/service-error-classification@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/service-error-classification@npm:3.329.0"
-  checksum: 77b19ffd3fa926b3e4b5f5aee64ff3159af6fa7c9f3a643fe7505690a2bd7d67e2ff8790ea3be21458c95c0eeb65687e4dd01140c352d170549368c0ff908936
+"@aws-sdk/service-error-classification@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/service-error-classification@npm:3.357.0"
+  checksum: a29638c7724a94e6a8baf2c6249d647239a5ff3863f677a023a93c40e4658f00a98cd29e68bf9bcede9f4b85cd7970a9e9bfda410708695312d26d71cde6d6cf
   languageName: node
   linkType: hard
 
-"@aws-sdk/shared-ini-file-loader@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.329.0"
+"@aws-sdk/shared-ini-file-loader@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: ee5e57d38a17eb4ebb073daa3e1f91bf07c3a5746410470a628765e0b49176ac880a86b6e09279137fdda7a44a38666cb311fd3ed523d9a3c4d4766d1ebeeb7e
+  checksum: c0be3ef2b74e07abdc7e49a1b2997cb22965af92bd1ca45808c19a54ab4c4ac9444dc69008cdae7d4abe74f38b3c32a08bccc218274df377969ea4bf6839dca9
   languageName: node
   linkType: hard
 
-"@aws-sdk/signature-v4-multi-region@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.329.0"
+"@aws-sdk/signature-v4-multi-region@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.357.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.329.0
-    "@aws-sdk/signature-v4": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/signature-v4": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
   peerDependencies:
     "@aws-sdk/signature-v4-crt": ^3.118.0
   peerDependenciesMeta:
     "@aws-sdk/signature-v4-crt":
       optional: true
-  checksum: c9ae1a68919674b6444cdb64e865e08b72f6a6127c7f43bffbbfb7457d48efc9ea5c89e58e5e451d1ec28c0d735969e4985fee25a7bca5b9949264d8de2763fc
+  checksum: d28df5452fef6f041df70c0d95b037881e8fd3eb02a57eb19e3c3950a7fdf7e083442cc3b0896ba4a3407d70a0426050ede992c394e7bf3f02833beb1ce610b6
   languageName: node
   linkType: hard
 
-"@aws-sdk/signature-v4@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/signature-v4@npm:3.329.0"
+"@aws-sdk/signature-v4@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/signature-v4@npm:3.357.0"
   dependencies:
+    "@aws-sdk/eventstream-codec": 3.357.0
     "@aws-sdk/is-array-buffer": 3.310.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     "@aws-sdk/util-hex-encoding": 3.310.0
-    "@aws-sdk/util-middleware": 3.329.0
+    "@aws-sdk/util-middleware": 3.357.0
     "@aws-sdk/util-uri-escape": 3.310.0
     "@aws-sdk/util-utf8": 3.310.0
     tslib: ^2.5.0
-  checksum: 8bf81f260f8a6a75e43f172bc049b777d081ca75e8456b21331895c0dba2486b804a8e7aed12ebb178e421aacc515fc873141682d7100c045da60b9425b9c432
+  checksum: 8ef865093e6d60a1b6fcb28c4b0a06e34ed1013dedcc0f8aa35d2e300d48c6e6df00564146111b5f1b58197a4f4c68bedcb5330f4a8fc7a24db302eb21e23782
   languageName: node
   linkType: hard
 
-"@aws-sdk/smithy-client@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/smithy-client@npm:3.329.0"
+"@aws-sdk/smithy-client@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/smithy-client@npm:3.358.0"
   dependencies:
-    "@aws-sdk/middleware-stack": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/middleware-stack": 3.357.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/util-stream": 3.358.0
+    "@smithy/types": ^1.0.0
     tslib: ^2.5.0
-  checksum: 4235822be0165c44f780a704da01581c8f8476c6a11e2b421d6fa003a30e9ab3bb37c02289b5678194f6d89304b1a576a1fc79b646ac0c58b482f70ea24a4b16
+  checksum: 3db71a638ef10fb05e5e10d578014594cd77ccd0b6fba5771e7314b6f1e1d1fcee0ba61ffb9dd6f964480764ef9d0b6af091f6522cb8c44754a767c9d0629087
   languageName: node
   linkType: hard
 
-"@aws-sdk/token-providers@npm:3.335.0":
-  version: 3.335.0
-  resolution: "@aws-sdk/token-providers@npm:3.335.0"
+"@aws-sdk/token-providers@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/token-providers@npm:3.358.0"
   dependencies:
-    "@aws-sdk/client-sso-oidc": 3.335.0
-    "@aws-sdk/property-provider": 3.329.0
-    "@aws-sdk/shared-ini-file-loader": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/client-sso-oidc": 3.358.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/shared-ini-file-loader": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 4d12001ebc01d21b63d9251f407565228d62eb942a2afc229eefe2b3bf851f8a43ca0e8e9650d34f993525583a265318854c7ab50f974512f673e6b43e753062
+  checksum: 3038d2be78dade462c52761e37154231e5a5a531f732ecb7f7074ea7b7a84af91917113133539c85e08e262dc9d41257c22ca9d2233221e531709413c23b55d1
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.329.0, @aws-sdk/types@npm:^3.222.0, @aws-sdk/types@npm:^3.310.0":
+"@aws-sdk/types@npm:3.357.0, @aws-sdk/types@npm:^3.347.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/types@npm:3.357.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 41001b0ea7af2e09daca87f2fedb992bddd864f27f70c70acd62f95bc949ae0637f7100f2cff7a5618291d77c2146f157a863a2d7a4d2576ba2d6882fd4a75bd
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:^3.222.0":
   version: 3.329.0
   resolution: "@aws-sdk/types@npm:3.329.0"
   dependencies:
@@ -988,14 +999,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/url-parser@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/url-parser@npm:3.329.0"
+"@aws-sdk/url-parser@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/url-parser@npm:3.357.0"
   dependencies:
-    "@aws-sdk/querystring-parser": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/querystring-parser": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: d5640fb2c21ebca56904641204bd51bb14b9d7cc1ae76860ce2e7d51cf5c1e76b09eefb98678d67651de2773a7137509017f22a93c8f2e7451666e10100072ec
+  checksum: ff57a09fb603cf2a3f14f3f45bb09fec7ccd8c4afc525ca6a0c3e25858a3afbf1adb4024ff33292d12103207663e7c8a7c0eda03e6701173d5f8ab817e2190f8
   languageName: node
   linkType: hard
 
@@ -1055,39 +1066,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-defaults-mode-browser@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/util-defaults-mode-browser@npm:3.329.0"
+"@aws-sdk/util-defaults-mode-browser@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/util-defaults-mode-browser@npm:3.358.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/types": 3.357.0
     bowser: ^2.11.0
     tslib: ^2.5.0
-  checksum: 217995ed68d7af117a0efa163ec22b0ee1700d4d1a3f4a1a950298e239788743886453dfb91f07c2b6c341497d489cae142872e629f6701c65d689132527be0d
+  checksum: 39af5ddcac5411cdacbc477f0f9c61c51a73d967c376dc97c0e6b5ef0b5b6948e73d67118b3d8594d0fdbd99a47c62c0a5b3a832bcf64fd7cab8dc4e9fb52a98
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-defaults-mode-node@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/util-defaults-mode-node@npm:3.329.0"
+"@aws-sdk/util-defaults-mode-node@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/util-defaults-mode-node@npm:3.358.0"
   dependencies:
-    "@aws-sdk/config-resolver": 3.329.0
-    "@aws-sdk/credential-provider-imds": 3.329.0
-    "@aws-sdk/node-config-provider": 3.329.0
-    "@aws-sdk/property-provider": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/config-resolver": 3.357.0
+    "@aws-sdk/credential-provider-imds": 3.357.0
+    "@aws-sdk/node-config-provider": 3.357.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 8b727977205638940da63fe3a4a88862d7a9491c3409543e67a7a9ee071f4c2459d24ca2e078a412710a5fa2146f6644356fbda69b9f3a9046c7d65f14902b8d
+  checksum: 04c046290b515aec7dd27b1b6a45274922e714d96ffc21b02775e2f1053d907e12080a009d504bf6265df0c9db48b99ea3d06e2e2790c8b6131c7e426b22cb59
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-endpoints@npm:3.332.0":
-  version: 3.332.0
-  resolution: "@aws-sdk/util-endpoints@npm:3.332.0"
+"@aws-sdk/util-endpoints@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 039e7591321f1b19f7d3c658f9c5c87c10154be4e2d8c1006faedc1fcb05df424d7d930788c1a589c1da64f19562855e30249b134fa6f7c88029299c82070062
+  checksum: dcbe4a4ee0fe4490c64465c1dbaaf67d1da38fbc2e8d95e44f50dc4cc94c378b5d1e561c77d5d1c30bb89fb39891e24f1d3778dd8b1fda9305bc3529e3174fe5
   languageName: node
   linkType: hard
 
@@ -1109,48 +1120,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-middleware@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/util-middleware@npm:3.329.0"
+"@aws-sdk/util-middleware@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/util-middleware@npm:3.357.0"
   dependencies:
     tslib: ^2.5.0
-  checksum: 23bc1ab195d31871edb2a7c9b3772911e881a39d70dfacedcf6e0308cbe95ec0ccb09f5f41f52458bff621d8e44dd3a4c94336da213d6d8074ffa0c0e334fad2
+  checksum: 62d92b864a0b6843c83b838a5a850adfe551323ef2cf4d7510ff38f552b1483f09e8caa17f6e6eecf963c57302173e38f682016d45d87a68540b7adf3ec9a9a2
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-retry@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/util-retry@npm:3.329.0"
+"@aws-sdk/util-retry@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/util-retry@npm:3.357.0"
   dependencies:
-    "@aws-sdk/service-error-classification": 3.329.0
+    "@aws-sdk/service-error-classification": 3.357.0
     tslib: ^2.5.0
-  checksum: 56b5c3567f4b32d37faf93f69c7ca519a5300838065b896fdc291dbdd85e17551e00d44f536fb859e648ff2db2f1fb7176bc46aa2c44e5a947a3dd99b61f642e
+  checksum: f88181bfd1d03ab765467fdc8912e448d1b838f2852841f69ffd5537f62759bdfed88fbc9a8f8360957f233c6b0c3278eb2694bc742f587a91f5045cd0621c86
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-stream-browser@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/util-stream-browser@npm:3.329.0"
+"@aws-sdk/util-stream@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/util-stream@npm:3.358.0"
   dependencies:
-    "@aws-sdk/fetch-http-handler": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/fetch-http-handler": 3.357.0
+    "@aws-sdk/node-http-handler": 3.357.0
+    "@aws-sdk/types": 3.357.0
     "@aws-sdk/util-base64": 3.310.0
+    "@aws-sdk/util-buffer-from": 3.310.0
     "@aws-sdk/util-hex-encoding": 3.310.0
     "@aws-sdk/util-utf8": 3.310.0
     tslib: ^2.5.0
-  checksum: a3451714c437c7a33aefa52e37182d58d7ff8e632f1243ec40bba6a352a7e9a7c58fc8cb2f4ba68b969aadbae08290e7506b8c0762080e3502427d8c747f7644
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-stream-node@npm:3.331.0":
-  version: 3.331.0
-  resolution: "@aws-sdk/util-stream-node@npm:3.331.0"
-  dependencies:
-    "@aws-sdk/node-http-handler": 3.329.0
-    "@aws-sdk/types": 3.329.0
-    "@aws-sdk/util-buffer-from": 3.310.0
-    tslib: ^2.5.0
-  checksum: 5c9c6a97e8440b40d1d317d799ff4f951eb0c190e4d640eabf2a7f1c86cf057cebbada4b10944b7523bdab15fe4dc3ad4555f6dce0542599e9c4c848c63d2dca
+  checksum: 6bb0beba2aa7f93e00b304545072529118327f136ddb9a9eafdd36c82626d71435566cb7471547dff56629cd82e501a0451254b510206d568c1ad50ba0a8b2cc
   languageName: node
   linkType: hard
 
@@ -1163,30 +1164,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-browser@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.329.0"
+"@aws-sdk/util-user-agent-browser@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/types": 3.357.0
     bowser: ^2.11.0
     tslib: ^2.5.0
-  checksum: ced136d39db2eaa62621819025df1c881e909e37826322ad5d5cb78d51d8e866f88ac1fe90857543a8f7f1fa1111d50bd369fa49495e465a167769935410df45
+  checksum: ff41369496116bf9c754030a9679e2eac390eeb5ab88cc49b5df06aa564e156c71eace3458b9bf8e62a8f203c7e431475f498c138276649a6f9c549a0c6e252a
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-node@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.329.0"
+"@aws-sdk/util-user-agent-node@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.357.0"
   dependencies:
-    "@aws-sdk/node-config-provider": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/node-config-provider": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
   peerDependencies:
     aws-crt: ">=1.0.0"
   peerDependenciesMeta:
     aws-crt:
       optional: true
-  checksum: 33fae730d0cdb0743af867373f58201c5aea8e48a0f449c9df19c08269cc18fc4b523e481895e4ba5b2a43446ec417f12691249e8b0339c30849473f5f36085f
+  checksum: ea9578e519be09a43682dc90be3feab4c4d22e027355be059dac9a0df6de75ace7288be8ef9be94fdf70e3d5d510b1118b6c8d5f8becdde14bc9d90fe05b6e90
   languageName: node
   linkType: hard
 
@@ -1209,14 +1210,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-waiter@npm:3.329.0":
-  version: 3.329.0
-  resolution: "@aws-sdk/util-waiter@npm:3.329.0"
+"@aws-sdk/util-waiter@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/util-waiter@npm:3.357.0"
   dependencies:
-    "@aws-sdk/abort-controller": 3.329.0
-    "@aws-sdk/types": 3.329.0
+    "@aws-sdk/abort-controller": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 41f8796c3649313dee3cbc5a643c9bc1d23a54e35a990c41875a3397f18c57844a68e2f0efb585548f88f6047b7e2c31db8c833481839788cee3024bc92aad81
+  checksum: 5e1b68ba26c0581aacce2f3c1672e77d870b5e800fc4749cc024e20bc904969d012b496b9bb4e0917fad7560ba4255d2eb8f159379e557dcdff49d5e609c2c41
   languageName: node
   linkType: hard
 
@@ -1226,6 +1227,136 @@ __metadata:
   dependencies:
     tslib: ^2.5.0
   checksum: fc17fd8f68470702d947948ada46097bdddecafdc68fa57bf584320e92748e8ef0372a51999d3ab7902ba4f62c2dbfbdec2dba1180fca19bb5127bad1ef0e48b
+  languageName: node
+  linkType: hard
+
+"@azure/abort-controller@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "@azure/abort-controller@npm:1.1.0"
+  dependencies:
+    tslib: ^2.2.0
+  checksum: 0f45e504d4aea799486867179afe7589255f6c111951279958e9d0aa5faebb2c96b8f88e3e3c958ce07b02bcba0b0cddb1bbec94705f573a48ecdb93eec1a92a
+  languageName: node
+  linkType: hard
+
+"@azure/core-auth@npm:^1.3.0, @azure/core-auth@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "@azure/core-auth@npm:1.4.0"
+  dependencies:
+    "@azure/abort-controller": ^1.0.0
+    tslib: ^2.2.0
+  checksum: 1c76c296fe911ad39fc780b033c25a92c41c5a15f011b816d42c13584f627a4dd153dfb4334900ec93eb5b006e14bdda37e8412a7697c5a9636a0abaccffad39
+  languageName: node
+  linkType: hard
+
+"@azure/core-client@npm:^1.4.0":
+  version: 1.7.3
+  resolution: "@azure/core-client@npm:1.7.3"
+  dependencies:
+    "@azure/abort-controller": ^1.0.0
+    "@azure/core-auth": ^1.4.0
+    "@azure/core-rest-pipeline": ^1.9.1
+    "@azure/core-tracing": ^1.0.0
+    "@azure/core-util": ^1.0.0
+    "@azure/logger": ^1.0.0
+    tslib: ^2.2.0
+  checksum: 155a188b75b2d5ea783d5fde50479337c41796736f0fced1576466c8251e429195c229f2aff0bf897761f15c19d8fd0deea9a54aab514bd3584e37140e3f0cdc
+  languageName: node
+  linkType: hard
+
+"@azure/core-rest-pipeline@npm:^1.1.0, @azure/core-rest-pipeline@npm:^1.9.1":
+  version: 1.11.0
+  resolution: "@azure/core-rest-pipeline@npm:1.11.0"
+  dependencies:
+    "@azure/abort-controller": ^1.0.0
+    "@azure/core-auth": ^1.4.0
+    "@azure/core-tracing": ^1.0.1
+    "@azure/core-util": ^1.3.0
+    "@azure/logger": ^1.0.0
+    form-data: ^4.0.0
+    http-proxy-agent: ^5.0.0
+    https-proxy-agent: ^5.0.0
+    tslib: ^2.2.0
+  checksum: e65b03022ba342b7788d3146eed5ddd36c7c99edf210bafd81aa55a921da08161735eb08b9177aceba5986eede53f13f8a3d064f03950b68348d877d098a6803
+  languageName: node
+  linkType: hard
+
+"@azure/core-tracing@npm:^1.0.0, @azure/core-tracing@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@azure/core-tracing@npm:1.0.1"
+  dependencies:
+    tslib: ^2.2.0
+  checksum: ae4309f8ab0b52c37f699594d58ee095782649f538bd6a0ee03e3fea042f55df7ad95c2e6dec22f5b8c3907e4bcf98d6ca98faaf480d446b73d41bbc1519d891
+  languageName: node
+  linkType: hard
+
+"@azure/core-util@npm:^1.0.0, @azure/core-util@npm:^1.3.0":
+  version: 1.3.2
+  resolution: "@azure/core-util@npm:1.3.2"
+  dependencies:
+    "@azure/abort-controller": ^1.0.0
+    tslib: ^2.2.0
+  checksum: c26053a209ed99c5b31ec54bd456155a7e602fda0b680ba326063ee42427efe60042124fbf22701397647e822bee252f77fec449e8f8100c406b8ca7168c8359
+  languageName: node
+  linkType: hard
+
+"@azure/identity@npm:^3.2.1":
+  version: 3.2.3
+  resolution: "@azure/identity@npm:3.2.3"
+  dependencies:
+    "@azure/abort-controller": ^1.0.0
+    "@azure/core-auth": ^1.3.0
+    "@azure/core-client": ^1.4.0
+    "@azure/core-rest-pipeline": ^1.1.0
+    "@azure/core-tracing": ^1.0.0
+    "@azure/core-util": ^1.0.0
+    "@azure/logger": ^1.0.0
+    "@azure/msal-browser": ^2.37.1
+    "@azure/msal-common": ^13.1.0
+    "@azure/msal-node": ^1.17.3
+    events: ^3.0.0
+    jws: ^4.0.0
+    open: ^8.0.0
+    stoppable: ^1.1.0
+    tslib: ^2.2.0
+    uuid: ^8.3.0
+  checksum: 8f74831a358f41490056fb1978d9214542f5e7a788cc607ded3c475e1e61784da2cb6409434cb736c66291c24b755dbab42ec7b93b218ca535dce3363183c64b
+  languageName: node
+  linkType: hard
+
+"@azure/logger@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "@azure/logger@npm:1.0.4"
+  dependencies:
+    tslib: ^2.2.0
+  checksum: 2c243d4c667bbc5cd3e60d4473d0f1169fcef2498a02138398af15547fe1b2870197bcb4c487327451488e4d71dee05244771d51328f03611e193b99fb9aa9af
+  languageName: node
+  linkType: hard
+
+"@azure/msal-browser@npm:^2.37.1":
+  version: 2.37.1
+  resolution: "@azure/msal-browser@npm:2.37.1"
+  dependencies:
+    "@azure/msal-common": 13.1.0
+  checksum: 920b892bcdbc10f5e736e87363cb5964e48e8dcaf20f777f634308a5bc25550a7b02f62e826c1e3b50212e47e14435f9c3a4f72befc955392f0c4327e62518d0
+  languageName: node
+  linkType: hard
+
+"@azure/msal-common@npm:13.1.0, @azure/msal-common@npm:^13.1.0":
+  version: 13.1.0
+  resolution: "@azure/msal-common@npm:13.1.0"
+  checksum: db21145f824f02f63a10fa7e1a356445e0c9e945bb1685a964416f1788a89fca165302d990cdfffb7e794b92dac1c90e4934ed018e92056682f863b0eec82587
+  languageName: node
+  linkType: hard
+
+"@azure/msal-node@npm:^1.17.3":
+  version: 1.17.3
+  resolution: "@azure/msal-node@npm:1.17.3"
+  dependencies:
+    "@azure/msal-common": 13.1.0
+    jsonwebtoken: ^9.0.0
+    uuid: ^8.3.0
+  checksum: 6afc815116196e481dd7f2c142b9935dce1fa2b225c87c5e3615d83ecc00e4ff65295f512a9b03349a71c8cf19d6c25e0551dd33a55a4550f77dfa98ccbbc0fd
   languageName: node
   linkType: hard
 
@@ -1405,6 +1536,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-imports@npm:^7.16.7":
+  version: 7.22.5
+  resolution: "@babel/helper-module-imports@npm:7.22.5"
+  dependencies:
+    "@babel/types": ^7.22.5
+  checksum: 9ac2b0404fa38b80bdf2653fbeaf8e8a43ccb41bd505f9741d820ed95d3c4e037c62a1bcdcb6c9527d7798d2e595924c4d025daed73283badc180ada2c9c49ad
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-imports@npm:^7.18.6, @babel/helper-module-imports@npm:^7.21.4":
   version: 7.21.4
   resolution: "@babel/helper-module-imports@npm:7.21.4"
@@ -1508,10 +1648,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-string-parser@npm:7.22.5"
+  checksum: 836851ca5ec813077bbb303acc992d75a360267aa3b5de7134d220411c852a6f17de7c0d0b8c8dcc0f567f67874c00f4528672b2a4f1bc978a3ada64c8c78467
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.18.6, @babel/helper-validator-identifier@npm:^7.19.1":
   version: 7.19.1
   resolution: "@babel/helper-validator-identifier@npm:7.19.1"
   checksum: 0eca5e86a729162af569b46c6c41a63e18b43dbe09fda1d2a3c8924f7d617116af39cac5e4cd5d431bb760b4dca3c0970e0c444789b1db42bcf1fa41fbad0a3a
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-validator-identifier@npm:7.22.5"
+  checksum: 7f0f30113474a28298c12161763b49de5018732290ca4de13cdaefd4fd0d635a6fe3f6686c37a02905fb1e64f21a5ee2b55140cf7b070e729f1bd66866506aea
   languageName: node
   linkType: hard
 
@@ -2628,6 +2782,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/types@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/types@npm:7.22.5"
+  dependencies:
+    "@babel/helper-string-parser": ^7.22.5
+    "@babel/helper-validator-identifier": ^7.22.5
+    to-fast-properties: ^2.0.0
+  checksum: c13a9c1dc7d2d1a241a2f8363540cb9af1d66e978e8984b400a20c4f38ba38ca29f06e26a0f2d49a70bad9e57615dac09c35accfddf1bb90d23cd3e0a0bab892
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.8.3":
   version: 7.22.0
   resolution: "@babel/types@npm:7.22.0"
@@ -2639,39 +2804,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/app-defaults@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "@backstage/app-defaults@npm:1.3.1"
+"@backstage/app-defaults@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "@backstage/app-defaults@npm:1.4.0"
   dependencies:
-    "@backstage/core-app-api": ^1.8.0
-    "@backstage/core-components": ^0.13.1
-    "@backstage/core-plugin-api": ^1.5.1
-    "@backstage/plugin-permission-react": ^0.4.12
-    "@backstage/theme": ^0.3.0
+    "@backstage/core-app-api": ^1.8.1
+    "@backstage/core-components": ^0.13.2
+    "@backstage/core-plugin-api": ^1.5.2
+    "@backstage/plugin-permission-react": ^0.4.13
+    "@backstage/theme": ^0.4.0
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
   peerDependencies:
     react: ^16.13.1 || ^17.0.0
     react-dom: ^16.13.1 || ^17.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 35f4caac347b4c06910ed59a0d107468448cc5b17bf6d318a349527aeb34251a98feebca74af9ec2e162668d5740bc843137a8c571171f551cb810b6589f804d
+  checksum: 197f7593997b901cfeec0dd1ef7cf586f631183b2e0b4f0d2733552c6b16fc43bb51b6443a077913e60b018c94d5e0009bdc70b04324690e89133386b7745e0a
   languageName: node
   linkType: hard
 
-"@backstage/backend-app-api@npm:^0.4.3":
-  version: 0.4.3
-  resolution: "@backstage/backend-app-api@npm:0.4.3"
+"@backstage/backend-app-api@npm:^0.4.4":
+  version: 0.4.4
+  resolution: "@backstage/backend-app-api@npm:0.4.4"
   dependencies:
-    "@backstage/backend-common": ^0.18.5
-    "@backstage/backend-plugin-api": ^0.5.2
-    "@backstage/backend-tasks": ^0.5.2
+    "@backstage/backend-common": ^0.19.0
+    "@backstage/backend-plugin-api": ^0.5.3
+    "@backstage/backend-tasks": ^0.5.3
     "@backstage/cli-common": ^0.1.12
-    "@backstage/config": ^1.0.7
-    "@backstage/config-loader": ^1.3.0
-    "@backstage/errors": ^1.1.5
-    "@backstage/plugin-auth-node": ^0.2.14
-    "@backstage/plugin-permission-node": ^0.7.8
-    "@backstage/types": ^1.0.2
+    "@backstage/config": ^1.0.8
+    "@backstage/config-loader": ^1.3.1
+    "@backstage/errors": ^1.2.0
+    "@backstage/plugin-auth-node": ^0.2.15
+    "@backstage/plugin-permission-node": ^0.7.9
+    "@backstage/types": ^1.1.0
     "@manypkg/get-packages": ^1.1.3
     "@types/cors": ^2.8.6
     "@types/express": ^4.17.6
@@ -2691,28 +2856,28 @@ __metadata:
     stoppable: ^1.1.0
     winston: ^3.2.1
     winston-transport: ^4.5.0
-  checksum: 7e8e6f92cf84f152023a1a31833f28eb0323c1c51753264db0e17c025c61f1dd9d82fa794292a92bc8e84efdac471651e1907ad44173a22894773e55b354da23
+  checksum: dfc6dbe8c004fd07a1aeee2995c547a7ab06e87d19b00964e69ccbfbbbcf3f32052768a35058780fdbcdd2a582ac12f7fd9960b7bf39a18c0807c3e0c11179a9
   languageName: node
   linkType: hard
 
-"@backstage/backend-common@npm:^0.18.0, @backstage/backend-common@npm:^0.18.5":
-  version: 0.18.5
-  resolution: "@backstage/backend-common@npm:0.18.5"
+"@backstage/backend-common@npm:^0.19.0":
+  version: 0.19.0
+  resolution: "@backstage/backend-common@npm:0.19.0"
   dependencies:
-    "@aws-sdk/abort-controller": ^3.310.0
-    "@aws-sdk/client-s3": ^3.310.0
-    "@aws-sdk/credential-providers": ^3.310.0
-    "@aws-sdk/types": ^3.310.0
-    "@backstage/backend-app-api": ^0.4.3
+    "@aws-sdk/abort-controller": ^3.347.0
+    "@aws-sdk/client-s3": ^3.350.0
+    "@aws-sdk/credential-providers": ^3.350.0
+    "@aws-sdk/types": ^3.347.0
+    "@backstage/backend-app-api": ^0.4.4
     "@backstage/backend-dev-utils": ^0.1.1
-    "@backstage/backend-plugin-api": ^0.5.2
+    "@backstage/backend-plugin-api": ^0.5.3
     "@backstage/cli-common": ^0.1.12
-    "@backstage/config": ^1.0.7
-    "@backstage/config-loader": ^1.3.0
-    "@backstage/errors": ^1.1.5
-    "@backstage/integration": ^1.4.5
-    "@backstage/integration-aws-node": ^0.1.3
-    "@backstage/types": ^1.0.2
+    "@backstage/config": ^1.0.8
+    "@backstage/config-loader": ^1.3.1
+    "@backstage/errors": ^1.2.0
+    "@backstage/integration": ^1.5.0
+    "@backstage/integration-aws-node": ^0.1.4
+    "@backstage/types": ^1.1.0
     "@google-cloud/storage": ^6.0.0
     "@keyv/memcache": ^1.3.5
     "@keyv/redis": ^2.5.3
@@ -2762,7 +2927,7 @@ __metadata:
   peerDependenciesMeta:
     pg-connection-string:
       optional: true
-  checksum: d4fa358d1c2b7f243bbcbb78a4248ccd07e2be530146443b287caaac17c1f75caa2e692f397c4dca272c6c1b62b70edc5ca6f491bfcea830b755281a3477264a
+  checksum: 434b1ac4c0c10f23c4bcf5eb0c26663fe5cb9ac295cde22a7bbd7d91e87beb6bea23465ced9452c97a0e11cdea27bc6f75fc55d52250e19f7d906351ea6ac23e
   languageName: node
   linkType: hard
 
@@ -2773,30 +2938,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@npm:^0.5.2":
-  version: 0.5.2
-  resolution: "@backstage/backend-plugin-api@npm:0.5.2"
+"@backstage/backend-plugin-api@npm:^0.5.3":
+  version: 0.5.3
+  resolution: "@backstage/backend-plugin-api@npm:0.5.3"
   dependencies:
-    "@backstage/backend-tasks": ^0.5.2
-    "@backstage/config": ^1.0.7
-    "@backstage/plugin-auth-node": ^0.2.14
-    "@backstage/plugin-permission-common": ^0.7.5
-    "@backstage/types": ^1.0.2
+    "@backstage/backend-tasks": ^0.5.3
+    "@backstage/config": ^1.0.8
+    "@backstage/plugin-auth-node": ^0.2.15
+    "@backstage/plugin-permission-common": ^0.7.6
+    "@backstage/types": ^1.1.0
     "@types/express": ^4.17.6
     express: ^4.17.1
     knex: ^2.0.0
-  checksum: 6bab6d43ce4794cbb0656fc9fcdd08ec869418742018f0e5816bf00367a1ad8b7dc4a34e6a25225bace1c90ddf51608e34f902e22afb85537a081b307d79b291
+  checksum: 86e835ed1ab6f4d201e7079970fa87316f1403ffcdc76158172a3fcf9807c140dcf0512351307955e4d99119b64f03cc212b8940e5c6ad4d1d1af7acefbeebc8
   languageName: node
   linkType: hard
 
-"@backstage/backend-tasks@npm:^0.5.2":
-  version: 0.5.2
-  resolution: "@backstage/backend-tasks@npm:0.5.2"
+"@backstage/backend-tasks@npm:^0.5.3":
+  version: 0.5.3
+  resolution: "@backstage/backend-tasks@npm:0.5.3"
   dependencies:
-    "@backstage/backend-common": ^0.18.5
-    "@backstage/config": ^1.0.7
-    "@backstage/errors": ^1.1.5
-    "@backstage/types": ^1.0.2
+    "@backstage/backend-common": ^0.19.0
+    "@backstage/config": ^1.0.8
+    "@backstage/errors": ^1.2.0
+    "@backstage/types": ^1.1.0
     "@types/luxon": ^3.0.0
     cron: ^2.0.0
     knex: ^2.0.0
@@ -2805,33 +2970,33 @@ __metadata:
     uuid: ^8.0.0
     winston: ^3.2.1
     zod: ^3.21.4
-  checksum: e765546a13b73ef5dd9e242337c3015b2a7a000722158ea639fd47c1034ce9602a3ad8bb748b276836be8590fc3ef463f18102904f32eed0ead7e3e45036fe75
+  checksum: fbb6f1f49990ab3903de10899489062820907bf795dcc89933963cdae60dea9aa1555b37fc66015eeee696c26e38413dd2a2f3da99548950333710adf9beaf3c
   languageName: node
   linkType: hard
 
-"@backstage/catalog-client@npm:^1.4.1":
-  version: 1.4.1
-  resolution: "@backstage/catalog-client@npm:1.4.1"
+"@backstage/catalog-client@npm:^1.4.2":
+  version: 1.4.2
+  resolution: "@backstage/catalog-client@npm:1.4.2"
   dependencies:
-    "@backstage/catalog-model": ^1.3.0
-    "@backstage/errors": ^1.1.5
+    "@backstage/catalog-model": ^1.4.0
+    "@backstage/errors": ^1.2.0
     cross-fetch: ^3.1.5
-  checksum: 21d6ae8191f97c80b8f75b0a8b9b1d7a0255c865f0c8e08b5bb72492a1cca4769bb1d9766d0c6307910cc1dd41c14abd02307f626772de14e4ebda23b5773465
+  checksum: 26e0ed93d9ff0c477a93f075cdd19e7ce5c4b3923134b5f3e9684bb496cf3aeb6d729561c1ceb18866ccd3b901b76ed58db8c95e37b0d5d80dbb3f1024bad86f
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@npm:^1.1.5, @backstage/catalog-model@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@backstage/catalog-model@npm:1.3.0"
+"@backstage/catalog-model@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "@backstage/catalog-model@npm:1.4.0"
   dependencies:
-    "@backstage/config": ^1.0.7
-    "@backstage/errors": ^1.1.5
-    "@backstage/types": ^1.0.2
+    "@backstage/config": ^1.0.8
+    "@backstage/errors": ^1.2.0
+    "@backstage/types": ^1.1.0
     ajv: ^8.10.0
     json-schema: ^0.4.0
     lodash: ^4.17.21
     uuid: ^8.0.0
-  checksum: 728cc73f0e68453eba15db7fb54c6a3c44cb4a511fb65542302b285e5e8d6385332d27c681af5352bb31659e08b7f0899635ea9800a49c288707fc03031c7234
+  checksum: 867c8d54687575e0ca50b8fd1e4a51523d6632fb66af89b771fbfccd6ecd5846285cf9f7257914391cf898cff34d4457857bc17a15cedf36726d26bce8a94187
   languageName: node
   linkType: hard
 
@@ -2842,36 +3007,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-node@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@backstage/cli-node@npm:0.1.0"
+"@backstage/cli-node@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "@backstage/cli-node@npm:0.1.1"
   dependencies:
     "@backstage/cli-common": ^0.1.12
-    "@backstage/errors": ^1.1.5
-    "@backstage/types": ^1.0.2
+    "@backstage/errors": ^1.2.0
+    "@backstage/types": ^1.1.0
     "@manypkg/get-packages": ^1.1.3
     "@yarnpkg/parsers": ^3.0.0-rc.4
     fs-extra: 10.1.0
     semver: ^7.3.2
     zod: ^3.21.4
-  checksum: 79c169281976163954e7a1744de7a55be19c864a00621dc0a1967ea53e9b5633936c59b6d1518f61e8010888a2b689d8f6276404bbec7cd8a0bbc8d5add550fb
+  checksum: dbe9061c5e3ddb3c094983254002d39e32497fca3a27fe76abe5c419098dd48adfc1cd27979cca07bbceed0410ec53256348a1b5e4a925fa46ace2c735cfb6d4
   languageName: node
   linkType: hard
 
-"@backstage/cli@npm:^0.22.1, @backstage/cli@npm:^0.22.3":
-  version: 0.22.7
-  resolution: "@backstage/cli@npm:0.22.7"
+"@backstage/cli@npm:^0.22.8":
+  version: 0.22.8
+  resolution: "@backstage/cli@npm:0.22.8"
   dependencies:
+    "@backstage/catalog-model": ^1.4.0
     "@backstage/cli-common": ^0.1.12
-    "@backstage/cli-node": ^0.1.0
-    "@backstage/config": ^1.0.7
-    "@backstage/config-loader": ^1.3.0
-    "@backstage/errors": ^1.1.5
+    "@backstage/cli-node": ^0.1.1
+    "@backstage/config": ^1.0.8
+    "@backstage/config-loader": ^1.3.1
+    "@backstage/errors": ^1.2.0
     "@backstage/eslint-plugin": ^0.1.3
+    "@backstage/integration": ^1.5.0
     "@backstage/release-manifests": ^0.0.9
-    "@backstage/types": ^1.0.2
+    "@backstage/types": ^1.1.0
     "@esbuild-kit/cjs-loader": ^2.4.1
     "@manypkg/get-packages": ^1.1.3
+    "@octokit/graphql": ^5.0.0
+    "@octokit/graphql-schema": ^13.7.0
     "@octokit/oauth-app": ^4.2.0
     "@octokit/request": ^6.0.0
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.7
@@ -2902,6 +3071,7 @@ __metadata:
     chalk: ^4.0.0
     chokidar: ^3.3.1
     commander: ^9.1.0
+    cross-fetch: ^3.1.5
     cross-spawn: ^7.0.3
     css-loader: ^6.5.1
     diff: ^5.0.0
@@ -2920,6 +3090,7 @@ __metadata:
     express: ^4.17.1
     fork-ts-checker-webpack-plugin: ^7.0.0-alpha.8
     fs-extra: 10.1.0
+    git-url-parse: ^13.0.0
     glob: ^7.1.7
     global-agent: ^3.0.0
     handlebars: ^4.7.3
@@ -2970,18 +3141,18 @@ __metadata:
       optional: true
   bin:
     backstage-cli: bin/backstage-cli
-  checksum: dd471334f7562a5365edaad0a400e817950797f9f526d764df78e8c02d89eca98a355f267be8ee9445b60e319967555b2362863d07e154155ab813c11ad5fc13
+  checksum: 742cca7d1e422bf88508781fa635817a969ffeae2f006f9fa9ab6805b7ca6f541b46b68d8752e4f2741c407acf9e1e7e32fc666e2377e5da58f0704898a41565
   languageName: node
   linkType: hard
 
-"@backstage/config-loader@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@backstage/config-loader@npm:1.3.0"
+"@backstage/config-loader@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@backstage/config-loader@npm:1.3.1"
   dependencies:
     "@backstage/cli-common": ^0.1.12
-    "@backstage/config": ^1.0.7
-    "@backstage/errors": ^1.1.5
-    "@backstage/types": ^1.0.2
+    "@backstage/config": ^1.0.8
+    "@backstage/errors": ^1.2.0
+    "@backstage/types": ^1.1.0
     "@types/json-schema": ^7.0.6
     ajv: ^8.10.0
     chokidar: ^3.5.2
@@ -2995,27 +3166,27 @@ __metadata:
     typescript-json-schema: ^0.55.0
     yaml: ^2.0.0
     yup: ^0.32.9
-  checksum: 6fbebff26082346ef58a95bf830dccaa4772cc391244274189016f152a0ef61c7b3ba3a80e84ae15b9745c01150e6833dc4d0255830d172cb597bdf29440309b
+  checksum: feab69480f43a7ebd4751ac123439c89a51d31ce1eec43f5ad0041fccabd7cd9ac2be5f721a84747996ecd982e8d1dbe2c7c3fb9d86c93eb6558e79364603154
   languageName: node
   linkType: hard
 
-"@backstage/config@npm:^1.0.6, @backstage/config@npm:^1.0.7":
-  version: 1.0.7
-  resolution: "@backstage/config@npm:1.0.7"
+"@backstage/config@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "@backstage/config@npm:1.0.8"
   dependencies:
-    "@backstage/types": ^1.0.2
+    "@backstage/types": ^1.1.0
     lodash: ^4.17.21
-  checksum: 73bc7cd9b007f6fb0f29a46b20c6232dcafad4b1b7f4572950d350f35ba4a35027daf86fa5f68ef7bc17f4794206721e8ae960b5ba5db25ac3457c4e7e4feafa
+  checksum: 78c38207d52de65bf83c1b9281c83fc89e0cda9869c680c39e69bffed5200e5d35035cd850816b57fd979a2ea24132f96ee938b1cddacaf96a43d0385930da9a
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@npm:^1.0.0, @backstage/core-app-api@npm:^1.8.0":
-  version: 1.8.0
-  resolution: "@backstage/core-app-api@npm:1.8.0"
+"@backstage/core-app-api@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "@backstage/core-app-api@npm:1.8.1"
   dependencies:
-    "@backstage/config": ^1.0.7
-    "@backstage/core-plugin-api": ^1.5.1
-    "@backstage/types": ^1.0.2
+    "@backstage/config": ^1.0.8
+    "@backstage/core-plugin-api": ^1.5.2
+    "@backstage/types": ^1.1.0
     "@backstage/version-bridge": ^1.0.4
     "@types/prop-types": ^15.7.3
     "@types/react": ^16.13.1 || ^17.0.0
@@ -3028,18 +3199,18 @@ __metadata:
     react: ^16.13.1 || ^17.0.0
     react-dom: ^16.13.1 || ^17.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 4c6b90634fe64ff808b10f4d5ebeedc5d2d5bdad1bd4f97bf730c8b787f95265d47a04ee74fa5bdd0743d8ed5cd2cc7f876d4cedae54712c8d142e6ada9d41ed
+  checksum: c38ab40010ee7408a7b7c2a046f510e5f9ff13e134ea6230e0ce8b49340f3cea47e8f3f9e9f20f747e218de9be96ec19318adf4b909f8ab423efd36365678ef4
   languageName: node
   linkType: hard
 
-"@backstage/core-components@npm:^0.13.0, @backstage/core-components@npm:^0.13.1":
-  version: 0.13.1
-  resolution: "@backstage/core-components@npm:0.13.1"
+"@backstage/core-components@npm:^0.13.2":
+  version: 0.13.2
+  resolution: "@backstage/core-components@npm:0.13.2"
   dependencies:
-    "@backstage/config": ^1.0.7
-    "@backstage/core-plugin-api": ^1.5.1
-    "@backstage/errors": ^1.1.5
-    "@backstage/theme": ^0.3.0
+    "@backstage/config": ^1.0.8
+    "@backstage/core-plugin-api": ^1.5.2
+    "@backstage/errors": ^1.2.0
+    "@backstage/theme": ^0.4.0
     "@backstage/version-bridge": ^1.0.4
     "@date-io/core": ^1.3.13
     "@material-table/core": ^3.1.0
@@ -3081,16 +3252,16 @@ __metadata:
     react: ^16.13.1 || ^17.0.0
     react-dom: ^16.13.1 || ^17.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 9b1b40edb51ab4de6018d0fe063386b0e3f1b56b0427c98421cd5ccaffa790ccd9a5f70d36f6ebf5ce381a1b34ae4df5ffeef38c9074800fe38c352bd173003a
+  checksum: eb85037ada87ba3310a07b36b04bcbe7968482b1c741bb22babdab6dc74ee2d121c6dae278589c42e39fecde0e4313a451cc7c6366a92ee14e7a09b9e2c26d9d
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@npm:^1.0.0, @backstage/core-plugin-api@npm:^1.5.1":
-  version: 1.5.1
-  resolution: "@backstage/core-plugin-api@npm:1.5.1"
+"@backstage/core-plugin-api@npm:^1.5.2":
+  version: 1.5.2
+  resolution: "@backstage/core-plugin-api@npm:1.5.2"
   dependencies:
-    "@backstage/config": ^1.0.7
-    "@backstage/types": ^1.0.2
+    "@backstage/config": ^1.0.8
+    "@backstage/types": ^1.1.0
     "@backstage/version-bridge": ^1.0.4
     "@types/react": ^16.13.1 || ^17.0.0
     history: ^5.0.0
@@ -3100,23 +3271,23 @@ __metadata:
     react: ^16.13.1 || ^17.0.0
     react-dom: ^16.13.1 || ^17.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 59d75c906040ddd436135ab8a281792aec5cf5432f573b1273dba9c0b8b6f35861a899e17cc62417fe596d46903fc5807e632e49c5a8e43d866c639d71c0b86c
+  checksum: 50877e943b109d31502a45c3edec37da568e7bc866ae26fe527416c7b433b95baf33d2c04eb1e1dfc30c7d4a6916228c03af98e29c50e3ab5f133803d9105215
   languageName: node
   linkType: hard
 
-"@backstage/dev-utils@npm:^1.0.8":
-  version: 1.0.15
-  resolution: "@backstage/dev-utils@npm:1.0.15"
+"@backstage/dev-utils@npm:^1.0.16":
+  version: 1.0.16
+  resolution: "@backstage/dev-utils@npm:1.0.16"
   dependencies:
-    "@backstage/app-defaults": ^1.3.1
-    "@backstage/catalog-model": ^1.3.0
-    "@backstage/core-app-api": ^1.8.0
-    "@backstage/core-components": ^0.13.1
-    "@backstage/core-plugin-api": ^1.5.1
-    "@backstage/integration-react": ^1.1.13
-    "@backstage/plugin-catalog-react": ^1.6.0
-    "@backstage/test-utils": ^1.3.1
-    "@backstage/theme": ^0.3.0
+    "@backstage/app-defaults": ^1.4.0
+    "@backstage/catalog-model": ^1.4.0
+    "@backstage/core-app-api": ^1.8.1
+    "@backstage/core-components": ^0.13.2
+    "@backstage/core-plugin-api": ^1.5.2
+    "@backstage/integration-react": ^1.1.14
+    "@backstage/plugin-catalog-react": ^1.7.0
+    "@backstage/test-utils": ^1.4.0
+    "@backstage/theme": ^0.4.0
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@testing-library/dom": ^8.0.0
@@ -3130,18 +3301,18 @@ __metadata:
     react: ^16.13.1 || ^17.0.0
     react-dom: ^16.13.1 || ^17.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 861febfcfac880090c64c5d244ecd83611cdd25e548afb85f3ad7b4bae88b2508576445dc6fc41d9c1ff5ded637de06b4544b913ac148b53d99f5826aa903495
+  checksum: 37baa5498fe7528238bd645ae3a82a9a4100cb95f19f26fe6b9ce880ecd84d24f174ee9422dd4be2193bc1e4afa9ff3fe4fb3f2953dfc0f7b02438fd7cf07a12
   languageName: node
   linkType: hard
 
-"@backstage/errors@npm:^1.1.5":
-  version: 1.1.5
-  resolution: "@backstage/errors@npm:1.1.5"
+"@backstage/errors@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@backstage/errors@npm:1.2.0"
   dependencies:
-    "@backstage/types": ^1.0.2
+    "@backstage/types": ^1.1.0
     cross-fetch: ^3.1.5
     serialize-error: ^8.0.1
-  checksum: fb8cc933345511454f31d899fed113cb28ab90ad0fbfaf5fd12d1e1204a0c52cd45bdc897feae70cc90ce0fa6cd331542036f2a4cb82ee0c935c3d0a687d6ee0
+  checksum: dd2aa686de547f8f218943f80e4bad24d65c92308bd8be9e654fc9d2df84c7639bc0d505a9e3eaa83300e44d3994a547e2b0b990df4b5b8fd7e4a5e19d0cdea9
   languageName: node
   linkType: hard
 
@@ -3155,30 +3326,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-aws-node@npm:^0.1.3":
-  version: 0.1.3
-  resolution: "@backstage/integration-aws-node@npm:0.1.3"
+"@backstage/integration-aws-node@npm:^0.1.4":
+  version: 0.1.4
+  resolution: "@backstage/integration-aws-node@npm:0.1.4"
   dependencies:
-    "@aws-sdk/client-sts": ^3.310.0
-    "@aws-sdk/credential-provider-node": ^3.310.0
-    "@aws-sdk/credential-providers": ^3.310.0
-    "@aws-sdk/types": ^3.310.0
+    "@aws-sdk/client-sts": ^3.350.0
+    "@aws-sdk/credential-provider-node": ^3.350.0
+    "@aws-sdk/credential-providers": ^3.350.0
+    "@aws-sdk/types": ^3.347.0
     "@aws-sdk/util-arn-parser": ^3.310.0
-    "@backstage/config": ^1.0.7
-    "@backstage/errors": ^1.1.5
-  checksum: 0639f81f21aca22a819d5d52372e268d7f720a53023e40401c1d0a3994d9e41580af9dba1267c804d4cac9f5d5d657edc4706efb06d282a27825c3c461f0ab71
+    "@backstage/config": ^1.0.8
+    "@backstage/errors": ^1.2.0
+  checksum: a2db881e6c69a7894dcfd906b82e2dbebecfc23dde8599f2fc559e7be0c7ebcfe156be70885d6c47c84b83c77e874d486349716f46d63d5d3bf884be91a5dfb1
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@npm:^1.1.13":
-  version: 1.1.13
-  resolution: "@backstage/integration-react@npm:1.1.13"
+"@backstage/integration-react@npm:^1.1.14":
+  version: 1.1.14
+  resolution: "@backstage/integration-react@npm:1.1.14"
   dependencies:
-    "@backstage/config": ^1.0.7
-    "@backstage/core-components": ^0.13.1
-    "@backstage/core-plugin-api": ^1.5.1
-    "@backstage/integration": ^1.4.5
-    "@backstage/theme": ^0.3.0
+    "@backstage/config": ^1.0.8
+    "@backstage/core-components": ^0.13.2
+    "@backstage/core-plugin-api": ^1.5.2
+    "@backstage/integration": ^1.5.0
+    "@backstage/theme": ^0.4.0
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.61
@@ -3187,86 +3358,88 @@ __metadata:
     react: ^16.13.1 || ^17.0.0
     react-dom: ^16.13.1 || ^17.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 72cf0a87699a3a47a518eba0f86ea7980caa946498814ceb71dfed4c5f67ab47dd763289ab3090c1c50b427e368522c9495c4c6d3ffca9296ea4f48d59d40bdb
+  checksum: 605a06b51110b83da3fc1a887615997a622ccf48a920ccb0bab8f819474105dfcdcbadfc99af28078ab021665c027068820e971200e66e9c642f797aa1b6353f
   languageName: node
   linkType: hard
 
-"@backstage/integration@npm:^1.4.2, @backstage/integration@npm:^1.4.5":
-  version: 1.4.5
-  resolution: "@backstage/integration@npm:1.4.5"
+"@backstage/integration@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@backstage/integration@npm:1.5.0"
   dependencies:
-    "@backstage/config": ^1.0.7
-    "@backstage/errors": ^1.1.5
+    "@azure/identity": ^3.2.1
+    "@backstage/config": ^1.0.8
+    "@backstage/errors": ^1.2.0
     "@octokit/auth-app": ^4.0.0
     "@octokit/rest": ^19.0.3
     cross-fetch: ^3.1.5
     git-url-parse: ^13.0.0
     lodash: ^4.17.21
     luxon: ^3.0.0
-  checksum: 71e7c5d884ae36a7dc8592dea7dd2e8140f3761ff1c499da2b97a8fbee39ff25012021f0097bbedb728b34b4339a0719086f13f0afd6c5992042081f7733d22c
+  checksum: 48995991e1202213dbd5c908560f18c74267529c1ee19a268d104fe48b5ce2660fef97e7f918c58e2f3ace1c58bdf9dcf2cd85115e3b4fa17e7fb21f5f8df977
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-node@npm:^0.2.14":
-  version: 0.2.14
-  resolution: "@backstage/plugin-auth-node@npm:0.2.14"
+"@backstage/plugin-auth-node@npm:^0.2.15":
+  version: 0.2.15
+  resolution: "@backstage/plugin-auth-node@npm:0.2.15"
   dependencies:
-    "@backstage/backend-common": ^0.18.5
-    "@backstage/config": ^1.0.7
-    "@backstage/errors": ^1.1.5
+    "@backstage/backend-common": ^0.19.0
+    "@backstage/config": ^1.0.8
+    "@backstage/errors": ^1.2.0
     "@types/express": "*"
     express: ^4.17.1
     jose: ^4.6.0
     node-fetch: ^2.6.7
     winston: ^3.2.1
-  checksum: a380dfff29daf906ec0a41a5a850ab58b734568ad96297ff67c7776a8a35f95f29d44641976d27727f517e8db0ad067da276b4db1f074693bd162185c047eb69
+  checksum: 6847d648336338cac87ee355416e909eaec9baad15ec0a1d9179dacbcbf38e883fcb402f1c471c0f418129edacb12966f28f821de8dda11eff66cd7e84098589
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@npm:^1.0.10, @backstage/plugin-catalog-common@npm:^1.0.13":
-  version: 1.0.13
-  resolution: "@backstage/plugin-catalog-common@npm:1.0.13"
+"@backstage/plugin-catalog-common@npm:^1.0.14":
+  version: 1.0.14
+  resolution: "@backstage/plugin-catalog-common@npm:1.0.14"
   dependencies:
-    "@backstage/catalog-model": ^1.3.0
-    "@backstage/plugin-permission-common": ^0.7.5
-    "@backstage/plugin-search-common": ^1.2.3
-  checksum: 2e7de3a1be8ac4ac823bf200d8f1f10a3353ed873caa4534cdb5f0e328716f79d431aee39b8d7dbe67554c302b1252e6c14ea1aa35d1dca6a4c5e5db27baafa4
+    "@backstage/catalog-model": ^1.4.0
+    "@backstage/plugin-permission-common": ^0.7.6
+    "@backstage/plugin-search-common": ^1.2.4
+  checksum: cb9606fdb805740863dee7550b082ceb8ff12d4a1575c5275cd945897d9cc870e5222e925bd5ad9500449f92b1be46b9db385f406a441c61c29a90d09972b0f6
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@npm:^1.3.6":
-  version: 1.3.6
-  resolution: "@backstage/plugin-catalog-node@npm:1.3.6"
+"@backstage/plugin-catalog-node@npm:^1.3.7":
+  version: 1.3.7
+  resolution: "@backstage/plugin-catalog-node@npm:1.3.7"
   dependencies:
-    "@backstage/backend-plugin-api": ^0.5.2
-    "@backstage/catalog-client": ^1.4.1
-    "@backstage/catalog-model": ^1.3.0
-    "@backstage/errors": ^1.1.5
-    "@backstage/plugin-catalog-common": ^1.0.13
-    "@backstage/types": ^1.0.2
-  checksum: 09f27db139b7419c211e10761b71527575d3ba8d6400d461eec5ccb0a6472b6c35ac3cf0d4cbd84e0bc66653c15b2c973f167c42efbbf3c7dfe72d8e2f9352d9
+    "@backstage/backend-plugin-api": ^0.5.3
+    "@backstage/catalog-client": ^1.4.2
+    "@backstage/catalog-model": ^1.4.0
+    "@backstage/errors": ^1.2.0
+    "@backstage/plugin-catalog-common": ^1.0.14
+    "@backstage/types": ^1.1.0
+  checksum: 016ea610234836b6701d80b4fc5a8e06d8c6b721f38adca7f0e3a02aa9aa6b7b04f4a015a12317527cf5a2eede36047751e64d35ea95da9f325747c27964f05d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@npm:^1.2.3, @backstage/plugin-catalog-react@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "@backstage/plugin-catalog-react@npm:1.6.0"
+"@backstage/plugin-catalog-react@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "@backstage/plugin-catalog-react@npm:1.7.0"
   dependencies:
-    "@backstage/catalog-client": ^1.4.1
-    "@backstage/catalog-model": ^1.3.0
-    "@backstage/core-components": ^0.13.1
-    "@backstage/core-plugin-api": ^1.5.1
-    "@backstage/errors": ^1.1.5
-    "@backstage/integration": ^1.4.5
-    "@backstage/plugin-catalog-common": ^1.0.13
-    "@backstage/plugin-permission-common": ^0.7.5
-    "@backstage/plugin-permission-react": ^0.4.12
-    "@backstage/theme": ^0.3.0
-    "@backstage/types": ^1.0.2
+    "@backstage/catalog-client": ^1.4.2
+    "@backstage/catalog-model": ^1.4.0
+    "@backstage/core-components": ^0.13.2
+    "@backstage/core-plugin-api": ^1.5.2
+    "@backstage/errors": ^1.2.0
+    "@backstage/integration": ^1.5.0
+    "@backstage/plugin-catalog-common": ^1.0.14
+    "@backstage/plugin-permission-common": ^0.7.6
+    "@backstage/plugin-permission-react": ^0.4.13
+    "@backstage/theme": ^0.4.0
+    "@backstage/types": ^1.1.0
     "@backstage/version-bridge": ^1.0.4
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.61
+    "@react-hookz/web": ^23.0.0
     "@types/react": ^16.13.1 || ^17.0.0
     classnames: ^2.2.6
     jwt-decode: ^3.1.0
@@ -3280,50 +3453,50 @@ __metadata:
     react: ^16.13.1 || ^17.0.0
     react-dom: ^16.13.1 || ^17.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 17e7a05b2e26511a27ce4ff8b09a40b15adf2e09e4cc57937d3479d83972aeb2be0ef74840c7d5a7c433dd03b9773a6864ae87a638d53f75881ac0007f135cf2
+  checksum: a4f5093aaa633758bae4905bf907e875a072e5e5f8e6835b7b5776ca4f4d6b07db4192f90d5ec3068e5ff810f0dfb3dbd09324bdfa01d7bf7cd2bee8acd1fc43
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-common@npm:^0.7.5":
-  version: 0.7.5
-  resolution: "@backstage/plugin-permission-common@npm:0.7.5"
+"@backstage/plugin-permission-common@npm:^0.7.6":
+  version: 0.7.6
+  resolution: "@backstage/plugin-permission-common@npm:0.7.6"
   dependencies:
-    "@backstage/config": ^1.0.7
-    "@backstage/errors": ^1.1.5
-    "@backstage/types": ^1.0.2
+    "@backstage/config": ^1.0.8
+    "@backstage/errors": ^1.2.0
+    "@backstage/types": ^1.1.0
     cross-fetch: ^3.1.5
     uuid: ^8.0.0
     zod: ^3.21.4
-  checksum: 24bfdc412e987be1d6bfa9e8dc82e19b7046ac60b426db2d7d81cf8389078e3703bd028a9331d4b9f695bf20126db5b17f648d14c70505eba7618c3c1c3f2e87
+  checksum: de3363d6a78d6aff077c93c1477e976fa0ab45a62e203be6b20e80a72c3847546a47e138f227893295d5e064421f04af1ae0fcbb74a250a5823e9b363c452209
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-node@npm:^0.7.8":
-  version: 0.7.8
-  resolution: "@backstage/plugin-permission-node@npm:0.7.8"
+"@backstage/plugin-permission-node@npm:^0.7.9":
+  version: 0.7.9
+  resolution: "@backstage/plugin-permission-node@npm:0.7.9"
   dependencies:
-    "@backstage/backend-common": ^0.18.5
-    "@backstage/backend-plugin-api": ^0.5.2
-    "@backstage/config": ^1.0.7
-    "@backstage/errors": ^1.1.5
-    "@backstage/plugin-auth-node": ^0.2.14
-    "@backstage/plugin-permission-common": ^0.7.5
+    "@backstage/backend-common": ^0.19.0
+    "@backstage/backend-plugin-api": ^0.5.3
+    "@backstage/config": ^1.0.8
+    "@backstage/errors": ^1.2.0
+    "@backstage/plugin-auth-node": ^0.2.15
+    "@backstage/plugin-permission-common": ^0.7.6
     "@types/express": ^4.17.6
     express: ^4.17.1
     express-promise-router: ^4.1.0
     zod: ^3.21.4
     zod-to-json-schema: ^3.20.4
-  checksum: a71e631fe8d9c45e01f5803b65a3cf7b6c208e91088e3379864bc0293acfb5a5de96438aa47d30ddf46a4b15d9398f27de4d5298d11b34cb8a3b7d8767c7f2ea
+  checksum: c30dfdd714bb8f1a924b9490f38ad604db18d28f69ba754bd9cd19188620aa8fa5d2337dbf569b335112ef4b9904fbddc4ff3cb94a54fa4d52c333c15b0f34f5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-react@npm:^0.4.12":
-  version: 0.4.12
-  resolution: "@backstage/plugin-permission-react@npm:0.4.12"
+"@backstage/plugin-permission-react@npm:^0.4.13":
+  version: 0.4.13
+  resolution: "@backstage/plugin-permission-react@npm:0.4.13"
   dependencies:
-    "@backstage/config": ^1.0.7
-    "@backstage/core-plugin-api": ^1.5.1
-    "@backstage/plugin-permission-common": ^0.7.5
+    "@backstage/config": ^1.0.8
+    "@backstage/core-plugin-api": ^1.5.2
+    "@backstage/plugin-permission-common": ^0.7.6
     "@types/react": ^16.13.1 || ^17.0.0
     cross-fetch: ^3.1.5
     react-use: ^17.2.4
@@ -3332,17 +3505,17 @@ __metadata:
     react: ^16.13.1 || ^17.0.0
     react-dom: ^16.13.1 || ^17.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: c431772c887c52302ad640233fea16fab44dcc16436cf234e337602dcb47fd9e4afbc9eb89223199016e71f7f4a45276e3095bdc2ef1bf49e5c368cccfc87d06
+  checksum: c93392de23dff6cf5152cdd6c4cde50c79a370c562aae42a74c9655716c959bf40a50a01fe7427102b74f33a26ce4a38e467fe88bf66d4ff6cd9e3ad12b70984
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-common@npm:^1.2.3":
-  version: 1.2.3
-  resolution: "@backstage/plugin-search-common@npm:1.2.3"
+"@backstage/plugin-search-common@npm:^1.2.4":
+  version: 1.2.4
+  resolution: "@backstage/plugin-search-common@npm:1.2.4"
   dependencies:
-    "@backstage/plugin-permission-common": ^0.7.5
-    "@backstage/types": ^1.0.2
-  checksum: 79f5808c1d3c6bdcd659e4d9228efc6ddf5a5c3135ad87581070243cdcfdfd704136ff997c01fc736af2aa6bdd6ecdec467b6dcec7e4897600d6225491ed9410
+    "@backstage/plugin-permission-common": ^0.7.6
+    "@backstage/types": ^1.1.0
+  checksum: f0c7cdcad4d11b4dc0b1a4d08417b554b19eb89ced3c49620656a133bfbbc0057f7e2ae176e36e883ce0d29298fafe3a4b916b68d8ee96374b896635e33909ce
   languageName: node
   linkType: hard
 
@@ -3355,17 +3528,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/test-utils@npm:^1.0.0, @backstage/test-utils@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "@backstage/test-utils@npm:1.3.1"
+"@backstage/test-utils@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "@backstage/test-utils@npm:1.4.0"
   dependencies:
-    "@backstage/config": ^1.0.7
-    "@backstage/core-app-api": ^1.8.0
-    "@backstage/core-plugin-api": ^1.5.1
-    "@backstage/plugin-permission-common": ^0.7.5
-    "@backstage/plugin-permission-react": ^0.4.12
-    "@backstage/theme": ^0.3.0
-    "@backstage/types": ^1.0.2
+    "@backstage/config": ^1.0.8
+    "@backstage/core-app-api": ^1.8.1
+    "@backstage/core-plugin-api": ^1.5.2
+    "@backstage/plugin-permission-common": ^0.7.6
+    "@backstage/plugin-permission-react": ^0.4.13
+    "@backstage/theme": ^0.4.0
+    "@backstage/types": ^1.1.0
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@testing-library/dom": ^8.0.0
@@ -3379,38 +3552,30 @@ __metadata:
     react: ^16.13.1 || ^17.0.0
     react-dom: ^16.13.1 || ^17.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 066abc47944cb2ef1d6ff84afcb201da0b76aa327945394b93e7e9933f69828b1c184e67310f96042a7583cec1e6cd687db195b401290431fbaa28d1bb979bad
+  checksum: c35a3817ad82adbe86b0f279ed49fced6ec8862eb499becb5990e86add81e46b4ed141618cfadaf9c47e61f7217f630102bff6be010a5c5ac60e405fa6872bc8
   languageName: node
   linkType: hard
 
-"@backstage/theme@npm:^0.2.14":
-  version: 0.2.19
-  resolution: "@backstage/theme@npm:0.2.19"
+"@backstage/theme@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@backstage/theme@npm:0.4.0"
   dependencies:
-    "@material-ui/core": ^4.12.2
+    "@emotion/react": ^11.10.5
+    "@emotion/styled": ^11.10.5
+    "@mui/material": ^5.12.2
   peerDependencies:
+    "@material-ui/core": ^4.12.2
+    "@types/react": ^16.13.1 || ^17.0.0
     react: ^16.13.1 || ^17.0.0
     react-dom: ^16.13.1 || ^17.0.0
-  checksum: 93ca110a3f953d6d98b4a5f2163beaa1bd1f95adb66a593e85eb523a7012acf654b6148db54008a6434805a4bd9016d67e5c6a317bc56940ee6800aecbb97d6f
+  checksum: 12a78d2fe753a64dc65d930c7f5c6af6c356de882e2431b5d30d448e91db9f59640df92424c27c71fe4d795dbe7d71dff6b16772004cbd49f82430a73f653422
   languageName: node
   linkType: hard
 
-"@backstage/theme@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@backstage/theme@npm:0.3.0"
-  dependencies:
-    "@material-ui/core": ^4.12.2
-  peerDependencies:
-    react: ^16.13.1 || ^17.0.0
-    react-dom: ^16.13.1 || ^17.0.0
-  checksum: 3f9c9452a88d214c13c0136302641ee87424649bdc943c993e98fc7eb08904adf14719a7f5b7d863368d68b08276f18f4e5352c9661fcec78688fb52bd34a22f
-  languageName: node
-  linkType: hard
-
-"@backstage/types@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@backstage/types@npm:1.0.2"
-  checksum: 3fead10cfafa3d1a6490e664b52f383fa1bc2cc28cb4b63f2df9a299c654b1c7103c556f652eb8ebf17ca09133f841c75317a8215875c7701eb04737410d8321
+"@backstage/types@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@backstage/types@npm:1.1.0"
+  checksum: e93c3d10f151db087f611b1e25fb7a5ed5ec82cb3040c7bc3b04c058c6d8f889505310019707bf17a2bb3aa545e199de3f779914262a9eeaea73ff6ecc8e1dc8
   languageName: node
   linkType: hard
 
@@ -3690,10 +3855,156 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/babel-plugin@npm:^11.11.0":
+  version: 11.11.0
+  resolution: "@emotion/babel-plugin@npm:11.11.0"
+  dependencies:
+    "@babel/helper-module-imports": ^7.16.7
+    "@babel/runtime": ^7.18.3
+    "@emotion/hash": ^0.9.1
+    "@emotion/memoize": ^0.8.1
+    "@emotion/serialize": ^1.1.2
+    babel-plugin-macros: ^3.1.0
+    convert-source-map: ^1.5.0
+    escape-string-regexp: ^4.0.0
+    find-root: ^1.1.0
+    source-map: ^0.5.7
+    stylis: 4.2.0
+  checksum: 6b363edccc10290f7a23242c06f88e451b5feb2ab94152b18bb8883033db5934fb0e421e2d67d09907c13837c21218a3ac28c51707778a54d6cd3706c0c2f3f9
+  languageName: node
+  linkType: hard
+
+"@emotion/cache@npm:^11.11.0":
+  version: 11.11.0
+  resolution: "@emotion/cache@npm:11.11.0"
+  dependencies:
+    "@emotion/memoize": ^0.8.1
+    "@emotion/sheet": ^1.2.2
+    "@emotion/utils": ^1.2.1
+    "@emotion/weak-memoize": ^0.3.1
+    stylis: 4.2.0
+  checksum: 8eb1dc22beaa20c21a2e04c284d5a2630a018a9d51fb190e52de348c8d27f4e8ca4bbab003d68b4f6cd9cc1c569ca747a997797e0f76d6c734a660dc29decf08
+  languageName: node
+  linkType: hard
+
 "@emotion/hash@npm:^0.8.0":
   version: 0.8.0
   resolution: "@emotion/hash@npm:0.8.0"
   checksum: 4b35d88a97e67275c1d990c96d3b0450451d089d1508619488fc0acb882cb1ac91e93246d471346ebd1b5402215941ef4162efe5b51534859b39d8b3a0e3ffaa
+  languageName: node
+  linkType: hard
+
+"@emotion/hash@npm:^0.9.1":
+  version: 0.9.1
+  resolution: "@emotion/hash@npm:0.9.1"
+  checksum: 716e17e48bf9047bf9383982c071de49f2615310fb4e986738931776f5a823bc1f29c84501abe0d3df91a3803c80122d24e28b57351bca9e01356ebb33d89876
+  languageName: node
+  linkType: hard
+
+"@emotion/is-prop-valid@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@emotion/is-prop-valid@npm:1.2.1"
+  dependencies:
+    "@emotion/memoize": ^0.8.1
+  checksum: 8f42dc573a3fad79b021479becb639b8fe3b60bdd1081a775d32388bca418ee53074c7602a4c845c5f75fa6831eb1cbdc4d208cc0299f57014ed3a02abcad16a
+  languageName: node
+  linkType: hard
+
+"@emotion/memoize@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "@emotion/memoize@npm:0.8.1"
+  checksum: a19cc01a29fcc97514948eaab4dc34d8272e934466ed87c07f157887406bc318000c69ae6f813a9001c6a225364df04249842a50e692ef7a9873335fbcc141b0
+  languageName: node
+  linkType: hard
+
+"@emotion/react@npm:^11.10.5":
+  version: 11.11.1
+  resolution: "@emotion/react@npm:11.11.1"
+  dependencies:
+    "@babel/runtime": ^7.18.3
+    "@emotion/babel-plugin": ^11.11.0
+    "@emotion/cache": ^11.11.0
+    "@emotion/serialize": ^1.1.2
+    "@emotion/use-insertion-effect-with-fallbacks": ^1.0.1
+    "@emotion/utils": ^1.2.1
+    "@emotion/weak-memoize": ^0.3.1
+    hoist-non-react-statics: ^3.3.1
+  peerDependencies:
+    react: ">=16.8.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: aec3c36650f5f0d3d4445ff44d73dd88712b1609645b6af3e6d08049cfbc51f1785fe13dea1a1d4ab1b0800d68f2339ab11e459687180362b1ef98863155aae5
+  languageName: node
+  linkType: hard
+
+"@emotion/serialize@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@emotion/serialize@npm:1.1.2"
+  dependencies:
+    "@emotion/hash": ^0.9.1
+    "@emotion/memoize": ^0.8.1
+    "@emotion/unitless": ^0.8.1
+    "@emotion/utils": ^1.2.1
+    csstype: ^3.0.2
+  checksum: 413c352e657f1b5e27ea6437b3ef7dcc3860669b7ae17fd5c18bfbd44e033af1acc56b64d252284a813ca4f3b3e1b0841c42d3fb08e02d2df56fd3cd63d72986
+  languageName: node
+  linkType: hard
+
+"@emotion/sheet@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "@emotion/sheet@npm:1.2.2"
+  checksum: d973273c9c15f1c291ca2269728bf044bd3e92a67bca87943fa9ec6c3cd2b034f9a6bfe95ef1b5d983351d128c75b547b43ff196a00a3875f7e1d269793cecfe
+  languageName: node
+  linkType: hard
+
+"@emotion/styled@npm:^11.10.5":
+  version: 11.11.0
+  resolution: "@emotion/styled@npm:11.11.0"
+  dependencies:
+    "@babel/runtime": ^7.18.3
+    "@emotion/babel-plugin": ^11.11.0
+    "@emotion/is-prop-valid": ^1.2.1
+    "@emotion/serialize": ^1.1.2
+    "@emotion/use-insertion-effect-with-fallbacks": ^1.0.1
+    "@emotion/utils": ^1.2.1
+  peerDependencies:
+    "@emotion/react": ^11.0.0-rc.0
+    react: ">=16.8.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 904f641aad3892c65d7d6c0808b036dae1e6d6dad4861c1c7dc0baa59977047c6cad220691206eba7b4059f1a1c6e6c1ef4ebb8c829089e280fa0f2164a01e6b
+  languageName: node
+  linkType: hard
+
+"@emotion/unitless@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "@emotion/unitless@npm:0.8.1"
+  checksum: 385e21d184d27853bb350999471f00e1429fa4e83182f46cd2c164985999d9b46d558dc8b9cc89975cb337831ce50c31ac2f33b15502e85c299892e67e7b4a88
+  languageName: node
+  linkType: hard
+
+"@emotion/use-insertion-effect-with-fallbacks@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@emotion/use-insertion-effect-with-fallbacks@npm:1.0.1"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 700b6e5bbb37a9231f203bb3af11295eed01d73b2293abece0bc2a2237015e944d7b5114d4887ad9a79776504aa51ed2a8b0ddbc117c54495dd01a6b22f93786
+  languageName: node
+  linkType: hard
+
+"@emotion/utils@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@emotion/utils@npm:1.2.1"
+  checksum: e0b44be0705b56b079c55faff93952150be69e79b660ae70ddd5b6e09fc40eb1319654315a9f34bb479d7f4ec94be6068c061abbb9e18b9778ae180ad5d97c73
+  languageName: node
+  linkType: hard
+
+"@emotion/weak-memoize@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@emotion/weak-memoize@npm:0.3.1"
+  checksum: b2be47caa24a8122622ea18cd2d650dbb4f8ad37b636dc41ed420c2e082f7f1e564ecdea68122b546df7f305b159bf5ab9ffee872abd0f052e687428459af594
   languageName: node
   linkType: hard
 
@@ -4190,13 +4501,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@immobiliarelabs/backstage-plugin-gitlab-backend@workspace:packages/gitlab-backend"
   dependencies:
-    "@backstage/backend-common": ^0.18.0
-    "@backstage/catalog-model": ^1.1.5
-    "@backstage/cli": ^0.22.1
-    "@backstage/config": ^1.0.6
-    "@backstage/integration": ^1.4.2
-    "@backstage/plugin-catalog-common": ^1.0.10
-    "@backstage/plugin-catalog-node": ^1.3.6
+    "@backstage/backend-common": ^0.19.0
+    "@backstage/catalog-model": ^1.4.0
+    "@backstage/cli": ^0.22.8
+    "@backstage/config": ^1.0.8
+    "@backstage/integration": ^1.5.0
+    "@backstage/plugin-catalog-common": ^1.0.14
+    "@backstage/plugin-catalog-node": ^1.3.7
     "@types/express": "*"
     "@types/supertest": ^2.0.12
     express: ^4.17.3
@@ -4213,14 +4524,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@immobiliarelabs/backstage-plugin-gitlab@workspace:packages/gitlab"
   dependencies:
-    "@backstage/cli": ^0.22.3
-    "@backstage/core-app-api": ^1.0.0
-    "@backstage/core-components": ^0.13.0
-    "@backstage/core-plugin-api": ^1.0.0
-    "@backstage/dev-utils": ^1.0.8
-    "@backstage/plugin-catalog-react": ^1.2.3
-    "@backstage/test-utils": ^1.0.0
-    "@backstage/theme": ^0.2.14
+    "@backstage/cli": ^0.22.8
+    "@backstage/core-app-api": ^1.8.1
+    "@backstage/core-components": ^0.13.2
+    "@backstage/core-plugin-api": ^1.5.2
+    "@backstage/dev-utils": ^1.0.16
+    "@backstage/plugin-catalog-react": ^1.7.0
+    "@backstage/test-utils": ^1.4.0
+    "@backstage/theme": ^0.4.0
     "@commitlint/cli": ^17.0.0
     "@commitlint/config-conventional": ^17.0.0
     "@gitbeaker/rest": ^39.0.0
@@ -5046,6 +5357,162 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/base@npm:5.0.0-beta.4":
+  version: 5.0.0-beta.4
+  resolution: "@mui/base@npm:5.0.0-beta.4"
+  dependencies:
+    "@babel/runtime": ^7.21.0
+    "@emotion/is-prop-valid": ^1.2.1
+    "@mui/types": ^7.2.4
+    "@mui/utils": ^5.13.1
+    "@popperjs/core": ^2.11.8
+    clsx: ^1.2.1
+    prop-types: ^15.8.1
+    react-is: ^18.2.0
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10dd9d8198f38085a12f27516da6284f773041b3b8e9f419a0c0c5d05c16944f0620ca5c55a08a7a26c88513d340db04276a3130273d8e253ade38cf18ad0f96
+  languageName: node
+  linkType: hard
+
+"@mui/core-downloads-tracker@npm:^5.13.4":
+  version: 5.13.4
+  resolution: "@mui/core-downloads-tracker@npm:5.13.4"
+  checksum: 2d709a3efe2d11e82a6c369b0b47dc2d488f292a3213083102e6afbf009282c18cdb4b263c0cf6194e5c0cdfd4c735e180e25704015003851459b682bb53e2c8
+  languageName: node
+  linkType: hard
+
+"@mui/material@npm:^5.12.2":
+  version: 5.13.5
+  resolution: "@mui/material@npm:5.13.5"
+  dependencies:
+    "@babel/runtime": ^7.21.0
+    "@mui/base": 5.0.0-beta.4
+    "@mui/core-downloads-tracker": ^5.13.4
+    "@mui/system": ^5.13.5
+    "@mui/types": ^7.2.4
+    "@mui/utils": ^5.13.1
+    "@types/react-transition-group": ^4.4.6
+    clsx: ^1.2.1
+    csstype: ^3.1.2
+    prop-types: ^15.8.1
+    react-is: ^18.2.0
+    react-transition-group: ^4.4.5
+  peerDependencies:
+    "@emotion/react": ^11.5.0
+    "@emotion/styled": ^11.3.0
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 8d45708111f2d118a83e702895850b2db1086eec848e068ec7c7630dd4a79acf571ac29297735e5307f570aa74ebb642cd2e89cfc35d6364c2ec0fadb9cc5eb9
+  languageName: node
+  linkType: hard
+
+"@mui/private-theming@npm:^5.13.1":
+  version: 5.13.1
+  resolution: "@mui/private-theming@npm:5.13.1"
+  dependencies:
+    "@babel/runtime": ^7.21.0
+    "@mui/utils": ^5.13.1
+    prop-types: ^15.8.1
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 7211eba333a595ebfb964f7f5a561fba89ad06fc3db9e7bba795f9230afd687aa7a66d1a2fddf9dc5a73e1044729f7b3061ae461bb25eed64068ca08e018a38b
+  languageName: node
+  linkType: hard
+
+"@mui/styled-engine@npm:^5.13.2":
+  version: 5.13.2
+  resolution: "@mui/styled-engine@npm:5.13.2"
+  dependencies:
+    "@babel/runtime": ^7.21.0
+    "@emotion/cache": ^11.11.0
+    csstype: ^3.1.2
+    prop-types: ^15.8.1
+  peerDependencies:
+    "@emotion/react": ^11.4.1
+    "@emotion/styled": ^11.3.0
+    react: ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+  checksum: e99f49755406b55a1595bf5d2727f0c0e3fd9f914dce1ea3b6cac826efe05038f8e4bde52580bd6a5a4c62ad59e5582bdde6c17abc10d80e61a64da168803391
+  languageName: node
+  linkType: hard
+
+"@mui/system@npm:^5.13.5":
+  version: 5.13.5
+  resolution: "@mui/system@npm:5.13.5"
+  dependencies:
+    "@babel/runtime": ^7.21.0
+    "@mui/private-theming": ^5.13.1
+    "@mui/styled-engine": ^5.13.2
+    "@mui/types": ^7.2.4
+    "@mui/utils": ^5.13.1
+    clsx: ^1.2.1
+    csstype: ^3.1.2
+    prop-types: ^15.8.1
+  peerDependencies:
+    "@emotion/react": ^11.5.0
+    "@emotion/styled": ^11.3.0
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: ff966eb5e4cfd2b0390b71c9b7495bcc5d10330efed1b3aa3340ea59d44699bc927f652fa6b20671ecd80c74bb9c3613d50d58b9e8e3f8bbff3309ca51356f11
+  languageName: node
+  linkType: hard
+
+"@mui/types@npm:^7.2.4":
+  version: 7.2.4
+  resolution: "@mui/types@npm:7.2.4"
+  peerDependencies:
+    "@types/react": "*"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 16bea0547492193a22fd1794382f314698a114f6c673825314c66b56766c3a9d305992cc495684722b7be16a1ecf7e6e48a79caa64f90c439b530e8c02611a61
+  languageName: node
+  linkType: hard
+
+"@mui/utils@npm:^5.13.1":
+  version: 5.13.1
+  resolution: "@mui/utils@npm:5.13.1"
+  dependencies:
+    "@babel/runtime": ^7.21.0
+    "@types/prop-types": ^15.7.5
+    "@types/react-is": ^18.2.0
+    prop-types: ^15.8.1
+    react-is: ^18.2.0
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+  checksum: 79cfc91e5a61311ac88680df3ea09f1218d0a5a766b6dadf0c5c9c72a3c36cbd903895ebb0f16497dcffb2e3601cb3b46742ae3c5e2c1f62d5ebf02babfd910f
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -5690,6 +6157,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@octokit/graphql-schema@npm:^13.7.0":
+  version: 13.10.0
+  resolution: "@octokit/graphql-schema@npm:13.10.0"
+  dependencies:
+    graphql: ^16.0.0
+    graphql-tag: ^2.10.3
+  checksum: fdec9c9a4df1f90b733ea0e24964744faceaf65e5d350b1727892e8e0e5821df1d29aec5cfa039925a044c6f56d4ed2028505108db7fbc0c68011053853c2411
+  languageName: node
+  linkType: hard
+
 "@octokit/graphql@npm:^5.0.0":
   version: 5.0.6
   resolution: "@octokit/graphql@npm:5.0.6"
@@ -6010,6 +6487,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@popperjs/core@npm:^2.11.8":
+  version: 2.11.8
+  resolution: "@popperjs/core@npm:2.11.8"
+  checksum: e5c69fdebf52a4012f6a1f14817ca8e9599cb1be73dd1387e1785e2ed5e5f0862ff817f420a87c7fc532add1f88a12e25aeb010ffcbdc98eace3d55ce2139cf0
+  languageName: node
+  linkType: hard
+
 "@react-hookz/deep-equal@npm:^1.0.4":
   version: 1.0.4
   resolution: "@react-hookz/deep-equal@npm:1.0.4"
@@ -6030,6 +6514,22 @@ __metadata:
     js-cookie:
       optional: true
   checksum: bb393f892c2c81deff37d5f18faf8ec17431a24994d72d88ec390dcc1579b27318a7c8c6260070c87b66e8c635e4daec4436c33abf2622f842d1567235ed457d
+  languageName: node
+  linkType: hard
+
+"@react-hookz/web@npm:^23.0.0":
+  version: 23.0.1
+  resolution: "@react-hookz/web@npm:23.0.1"
+  dependencies:
+    "@react-hookz/deep-equal": ^1.0.4
+  peerDependencies:
+    js-cookie: ^3.0.5
+    react: ^16.8 || ^17 || ^18
+    react-dom: ^16.8 || ^17 || ^18
+  peerDependenciesMeta:
+    js-cookie:
+      optional: true
+  checksum: 321770570c947321ba44de6ecee17337e4bb0c2a0c9d0dff5cf29e999faa2b7c1132c72a15aface46da9a709b715042ab48a30085d2a8feefba91aac96e82037
   languageName: node
   linkType: hard
 
@@ -7258,7 +7758,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:*, @types/prop-types@npm:^15.0.0, @types/prop-types@npm:^15.7.3":
+"@types/prop-types@npm:*, @types/prop-types@npm:^15.0.0, @types/prop-types@npm:^15.7.3, @types/prop-types@npm:^15.7.5":
   version: 15.7.5
   resolution: "@types/prop-types@npm:15.7.5"
   checksum: 5b43b8b15415e1f298243165f1d44390403bb2bd42e662bca3b5b5633fdd39c938e91b7fce3a9483699db0f7a715d08cef220c121f723a634972fdf596aec980
@@ -7297,6 +7797,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react-is@npm:^18.2.0":
+  version: 18.2.1
+  resolution: "@types/react-is@npm:18.2.1"
+  dependencies:
+    "@types/react": "*"
+  checksum: b44c3262efa2c68fa6fe2beb9ef86170b18305469461a3f97aa14943cc033cb21a26944f718bdb6434eea6e8f7fcba251c4f45b65b897a3fcf751b5a6003cf82
+  languageName: node
+  linkType: hard
+
 "@types/react-redux@npm:^7.1.20":
   version: 7.1.25
   resolution: "@types/react-redux@npm:7.1.25"
@@ -7327,7 +7836,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-transition-group@npm:^4.2.0":
+"@types/react-transition-group@npm:^4.2.0, @types/react-transition-group@npm:^4.4.6":
   version: 4.4.6
   resolution: "@types/react-transition-group@npm:4.4.6"
   dependencies:
@@ -8740,6 +9249,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-plugin-macros@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "babel-plugin-macros@npm:3.1.0"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+    cosmiconfig: ^7.0.0
+    resolve: ^1.19.0
+  checksum: 765de4abebd3e4688ebdfbff8571ddc8cd8061f839bb6c3e550b0344a4027b04c60491f843296ce3f3379fb356cc873d57a9ee6694262547eb822c14a25be9a6
+  languageName: node
+  linkType: hard
+
 "babel-plugin-polyfill-corejs2@npm:^0.3.3":
   version: 0.3.3
   resolution: "babel-plugin-polyfill-corejs2@npm:0.3.3"
@@ -9797,7 +10317,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:^1.0.2, clsx@npm:^1.0.4":
+"clsx@npm:^1.0.2, clsx@npm:^1.0.4, clsx@npm:^1.2.1":
   version: 1.2.1
   resolution: "clsx@npm:1.2.1"
   checksum: 30befca8019b2eb7dbad38cff6266cf543091dae2825c856a62a8ccf2c3ab9c2907c4d12b288b73101196767f66812365400a227581484a05f968b0307cfaf12
@@ -10342,7 +10862,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"convert-source-map@npm:^1.6.0, convert-source-map@npm:^1.7.0":
+"convert-source-map@npm:^1.5.0, convert-source-map@npm:^1.6.0, convert-source-map@npm:^1.7.0":
   version: 1.9.0
   resolution: "convert-source-map@npm:1.9.0"
   checksum: dc55a1f28ddd0e9485ef13565f8f756b342f9a46c4ae18b843fe3c30c675d058d6a4823eff86d472f187b176f0adf51ea7b69ea38be34be4a63cbbf91b0593c8
@@ -10826,7 +11346,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.0.2, csstype@npm:^3.0.6":
+"csstype@npm:^3.0.2, csstype@npm:^3.0.6, csstype@npm:^3.1.2":
   version: 3.1.2
   resolution: "csstype@npm:3.1.2"
   checksum: e1a52e6c25c1314d6beef5168da704ab29c5186b877c07d822bd0806717d9a265e8493a2e35ca7e68d0f5d472d43fac1cdce70fd79fd0853dff81f3028d857b5
@@ -12972,14 +13492,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:4.1.2":
-  version: 4.1.2
-  resolution: "fast-xml-parser@npm:4.1.2"
+"fast-xml-parser@npm:4.2.4":
+  version: 4.2.4
+  resolution: "fast-xml-parser@npm:4.2.4"
   dependencies:
     strnum: ^1.0.5
   bin:
     fxparser: src/cli/cli.js
-  checksum: 6a7d1b17057f8470e70603eddfa75f990625735d068d57ece861d0154ad8d27fda63c2831d07e1ecd7e68e993738b2448925cb9277d8c0ed68009623bbcd63c6
+  checksum: d3b4d0c0152c09f98def792769fca6bb3fa1d597f9745d9564451c239089bd86bdf573c9263b4944860028cb7edb81752d64399c1aff8b87c9225ecef96905f7
   languageName: node
   linkType: hard
 
@@ -13133,6 +13653,13 @@ __metadata:
     statuses: 2.0.1
     unpipe: ~1.0.0
   checksum: 92effbfd32e22a7dff2994acedbd9bcc3aa646a3e919ea6a53238090e87097f8ef07cced90aa2cc421abdf993aefbdd5b00104d55c7c5479a8d00ed105b45716
+  languageName: node
+  linkType: hard
+
+"find-root@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "find-root@npm:1.1.0"
+  checksum: b2a59fe4b6c932eef36c45a048ae8f93c85640212ebe8363164814990ee20f154197505965f3f4f102efc33bfb1cbc26fd17c4a2fc739ebc51b886b137cbefaf
   languageName: node
   linkType: hard
 
@@ -14048,10 +14575,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"graphql-tag@npm:^2.10.3":
+  version: 2.12.6
+  resolution: "graphql-tag@npm:2.12.6"
+  dependencies:
+    tslib: ^2.1.0
+  peerDependencies:
+    graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+  checksum: b15162a3d62f17b9b79302445b9ee330e041582f1c7faca74b9dec5daa74272c906ec1c34e1c50592bb6215e5c3eba80a309103f6ba9e4c1cddc350c46f010df
+  languageName: node
+  linkType: hard
+
 "graphql@npm:^15.0.0 || ^16.0.0":
   version: 16.6.0
   resolution: "graphql@npm:16.6.0"
   checksum: bf1d9e3c1938ce3c1a81e909bd3ead1ae4707c577f91cff1ca2eca474bfbc7873d5d7b942e1e9777ff5a8304421dba57a4b76d7a29eb19de8711cb70e3c2415e
+  languageName: node
+  linkType: hard
+
+"graphql@npm:^16.0.0":
+  version: 16.7.1
+  resolution: "graphql@npm:16.7.1"
+  checksum: c924d8428daf0e96a5ea43e9bc3cd1b6802899907d284478ac8f705c8fd233a0a51eef915f7569fb5de8acb2e85b802ccc6c85c2b157ad805c1e9adba5a299bd
   languageName: node
   linkType: hard
 
@@ -14329,7 +14874,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
+"hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.1, hoist-non-react-statics@npm:^3.3.2":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
   dependencies:
@@ -19830,7 +20375,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"open@npm:^8.0.9, open@npm:^8.4.0":
+"open@npm:^8.0.0, open@npm:^8.0.9, open@npm:^8.4.0":
   version: 8.4.2
   resolution: "open@npm:8.4.2"
   dependencies:
@@ -21719,7 +22264,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^18.0.0":
+"react-is@npm:^18.0.0, react-is@npm:^18.2.0":
   version: 18.2.0
   resolution: "react-is@npm:18.2.0"
   checksum: e72d0ba81b5922759e4aff17e0252bd29988f9642ed817f56b25a3e217e13eea8a7f2322af99a06edb779da12d5d636e9fda473d620df9a3da0df2a74141d53e
@@ -21852,7 +22397,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-transition-group@npm:^4.0.0, react-transition-group@npm:^4.4.0":
+"react-transition-group@npm:^4.0.0, react-transition-group@npm:^4.4.0, react-transition-group@npm:^4.4.5":
   version: 4.4.5
   resolution: "react-transition-group@npm:4.4.5"
   dependencies:
@@ -23464,6 +24009,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map@npm:^0.5.7":
+  version: 0.5.7
+  resolution: "source-map@npm:0.5.7"
+  checksum: 5dc2043b93d2f194142c7f38f74a24670cd7a0063acdaf4bf01d2964b402257ae843c2a8fa822ad5b71013b5fcafa55af7421383da919752f22ff488bc553f4d
+  languageName: node
+  linkType: hard
+
 "source-map@npm:^0.6.0, source-map@npm:^0.6.1, source-map@npm:~0.6.0, source-map@npm:~0.6.1":
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
@@ -24109,7 +24661,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylis@npm:^4.0.6":
+"stylis@npm:4.2.0, stylis@npm:^4.0.6":
   version: 4.2.0
   resolution: "stylis@npm:4.2.0"
   checksum: 0eb6cc1b866dc17a6037d0a82ac7fa877eba6a757443e79e7c4f35bacedbf6421fadcab4363b39667b43355cbaaa570a3cde850f776498e5450f32ed2f9b7584
@@ -24849,6 +25401,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:^2.2.0":
+  version: 2.5.3
+  resolution: "tslib@npm:2.5.3"
+  checksum: 88902b309afaf83259131c1e13da1dceb0ad1682a213143a1346a649143924d78cf3760c448b84d796938fd76127183894f8d85cbb3bf9c4fddbfcc140c0003c
+  languageName: node
+  linkType: hard
+
 "tsutils@npm:^3.21.0":
   version: 3.21.0
   resolution: "tsutils@npm:3.21.0"
@@ -25448,7 +26007,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:8.3.2, uuid@npm:^8.0.0, uuid@npm:^8.3.2":
+"uuid@npm:8.3.2, uuid@npm:^8.0.0, uuid@npm:^8.3.0, uuid@npm:^8.3.2":
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
   bin:


### PR DESCRIPTION
## 🚨 Proposed changes

After upgrading our backstage instance to the latest version, we found out these plugins were using really old versions, causing our yarn.lock to have many duplicated dependencies. Since there are some big changes in some of the packages, it makes sense to keep them up to date from time to time, to avoid bigger issues in the future.

I tested the packages with the newest versions and everything seems to be working as before, so no breaking changes are expected here.

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
-   [x] Dependency updates

(Not sure which option was the correct, I would guess bugfix is the closest one)
