### PR TITLE
feat: Add info card variant prop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,8 @@ $ yarn lint
 
 ## Contributors
 
-[@JellyBellyDev](https://github.com/JellyBellyDev)  
-[@simonecorsi](https://github.com/simonecorsi)  
-[@dnlup](https://github.com/dnlup)  
+[@JellyBellyDev](https://github.com/JellyBellyDev)
+[@simonecorsi](https://github.com/simonecorsi)
+[@dnlup](https://github.com/dnlup)
 [@antoniomuso](https://github.com/antoniomuso)
+[@sergeyshevch](https://github.com/sergeyshevch)

--- a/packages/gitlab/src/api/GitlabCIClient.ts
+++ b/packages/gitlab/src/api/GitlabCIClient.ts
@@ -317,7 +317,9 @@ export class GitlabCIClient implements GitlabCIApi {
         if (filePath.startsWith('./')) filePath = filePath.slice(2);
 
         const readmeStr = await this.callApi<string>(
-            `projects/${projectID}/repository/files/${encodeURIComponent(filePath)}/raw`,
+            `projects/${projectID}/repository/files/${encodeURIComponent(
+                filePath
+            )}/raw`,
             { ref: branch }
         );
 

--- a/packages/gitlab/src/components/widgets/LanguagesCard/LanguagesCard.tsx
+++ b/packages/gitlab/src/components/widgets/LanguagesCard/LanguagesCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Alert from '@material-ui/lab/Alert';
-import { InfoCard, Progress } from '@backstage/core-components';
+import { InfoCard, InfoCardVariants, Progress } from '@backstage/core-components';
 import { GitlabCIApiRef } from '../../../api';
 import { useApi } from '@backstage/core-plugin-api';
 import { useAsync } from 'react-use';
@@ -44,7 +44,11 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-export const LanguagesCard = ({}) => {
+type Props = {
+    variant?: InfoCardVariants;
+}
+
+export const LanguagesCard = (props: Props) => {
     const classes = useStyles();
     let barWidth = 0;
     let languageTitle = new String();
@@ -83,7 +87,7 @@ export const LanguagesCard = ({}) => {
     }
 
     return value ? (
-        <InfoCard title="Languages">
+        <InfoCard title="Languages" variant={props.variant}>
             <div className={classes.barContainer}>
                 {Object.entries(value).map((language, index: number) => {
                     barWidth = barWidth + language[1];
@@ -132,6 +136,6 @@ export const LanguagesCard = ({}) => {
             ))}
         </InfoCard>
     ) : (
-        <InfoCard title="Languages" />
+        <InfoCard title="Languages" variant={props.variant} />
     );
 };

--- a/packages/gitlab/src/components/widgets/MergeRequestStats/MergeRequestStats.tsx
+++ b/packages/gitlab/src/components/widgets/MergeRequestStats/MergeRequestStats.tsx
@@ -157,7 +157,7 @@ const MergeRequestStats = (props: Props) => {
             </Box>
         </InfoCard>
     ) : (
-        <InfoCard title="Merge Request Statistics" />
+        <InfoCard title="Merge Request Statistics" variant={props.variant} />
     );
 };
 

--- a/packages/gitlab/src/components/widgets/PeopleCard/PeopleCard.tsx
+++ b/packages/gitlab/src/components/widgets/PeopleCard/PeopleCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Alert from '@material-ui/lab/Alert';
-import { InfoCard, Progress } from '@backstage/core-components';
+import { InfoCard, InfoCardVariants, Progress } from '@backstage/core-components';
 import { GitlabCIApiRef } from '../../../api';
 import { useApi } from '@backstage/core-plugin-api';
 import { useAsync } from 'react-use';
@@ -32,7 +32,11 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-export const PeopleCard = ({}) => {
+type Props = {
+    variant?: InfoCardVariants;
+}
+
+export const PeopleCard = (props: Props) => {
     const classes = useStyles();
     const project_id = gitlabProjectId();
     const project_slug = gitlabProjectSlug();
@@ -120,7 +124,11 @@ export const PeopleCard = ({}) => {
         );
     }
     return (
-        <InfoCard title="People" className={classes.infoCard}>
+        <InfoCard
+            title="People"
+            className={classes.infoCard}
+            variant={props.variant}
+            >
             {value?.owners && (
                 <>
                     <PeopleList

--- a/packages/gitlab/src/components/widgets/ReadmeCard/ReadmeCard.tsx
+++ b/packages/gitlab/src/components/widgets/ReadmeCard/ReadmeCard.tsx
@@ -5,6 +5,7 @@ import {
     InfoCard,
     Progress,
     MarkdownContent,
+    InfoCardVariants,
 } from '@backstage/core-components';
 import { GitlabCIApiRef } from '../../../api';
 import { useApi } from '@backstage/core-plugin-api';
@@ -25,7 +26,11 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-export const ReadmeCard = ({}) => {
+type Props = {
+    variant?: InfoCardVariants;
+}
+
+export const ReadmeCard = (props: Props) => {
     const classes = useStyles();
     const project_id = gitlabProjectId();
     const project_slug = gitlabProjectSlug();
@@ -72,7 +77,7 @@ export const ReadmeCard = ({}) => {
     }
 
     return (
-        <InfoCard title="README" className={classes.infoCard}>
+        <InfoCard title="README" className={classes.infoCard} variant={props.variant}>
             <MarkdownContent
                 content={value?.readme || 'No README found'}
                 dialect="gfm"

--- a/packages/gitlab/src/components/widgets/ReleasesCard/ReleasesCard.tsx
+++ b/packages/gitlab/src/components/widgets/ReleasesCard/ReleasesCard.tsx
@@ -19,7 +19,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { Link, Grid } from '@material-ui/core';
 import LocalOfferOutlinedIcon from '@material-ui/icons/LocalOfferOutlined';
 import Alert from '@material-ui/lab/Alert';
-import { InfoCard, Progress } from '@backstage/core-components';
+import { InfoCard, InfoCardVariants, Progress } from '@backstage/core-components';
 import { GitlabCIApiRef } from '../../../api';
 import { useApi } from '@backstage/core-plugin-api';
 import { useAsync } from 'react-use';
@@ -110,6 +110,11 @@ export interface ReleasesCardProps {
      * Determines if the sort selector should be shown
      */
     showSortSelector?: boolean;
+
+    /**
+     * Determines InfoCard variant
+     */
+    variant?: InfoCardVariants
 }
 
 function makeFilter(
@@ -227,6 +232,7 @@ export const ReleasesCard = (props: ReleasesCardProps) => {
                     window.open(`${project_web_url}/-/releases`);
                 },
             }}
+            variant={props.variant}
             className={classes.infoCard}
         >
             <Grid container spacing={2} justifyContent="flex-start">


### PR DESCRIPTION
## 🚨 Proposed changes

Now InfoCard components don't have the ability to specify variant prop. In my case I need to specify 'gridItem' for correct alignment in the grid on the Overview tab

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
