### PR TITLE
feat: added security card

### DIFF
--- a/packages/gitlab/src/api/GitlabCIApi.ts
+++ b/packages/gitlab/src/api/GitlabCIApi.ts
@@ -41,6 +41,29 @@ export type GitlabProjectCoverageResponse = {
     };
 };
 
+export type GitlabProjectSecurityResponse = {
+    data: {
+        project?: {
+            pipelines?: {
+                nodes?: {
+                    jobs?: {
+                        nodes?: {
+                            artifacts?: {
+                                nodes?: {
+                                    fileType: string;
+                                    downloadPath: string;
+                                    name: string;
+                                    id: string | number;
+                                }[];
+                            };
+                        }[];
+                    };
+                }[];
+            };
+        };
+    };
+};
+
 export type GitlabCIApi = {
     getPipelineSummary(
         projectID: string | number
@@ -64,6 +87,10 @@ export type GitlabCIApi = {
         projectSlug: string,
         projectDefaultBranch: string
     ): Promise<GitlabProjectCoverageResponse | undefined>;
+    getSecurityReport(
+        projectSlug: string,
+        projectDefaultBranch: string
+    ): Promise<string | undefined>;
     getIssuesSummary(
         projectID: string | number
     ): Promise<IssueSchema[] | undefined>;


### PR DESCRIPTION
## 🚨 Proposed changes


This PR adds [SAST](https://docs.gitlab.com/ee/user/application_security/sast/) security scan card. Currently, it cannot work for two reasons:

1. The REPORT type cannot be downloaded with normal API. https://gitlab.com/gitlab-org/gitlab/-/issues/352644
2. You cannot use `downloadPath` because it is not an API, for this reason, the `PRIVATE-TOKEN` Header does not work.

We will need to wait until either one of the two issues is resolved.

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
