### PR TITLE
feat(immobiliare/backstage-plugin-gitlab#425): Added an empty release card when no releases are found

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ This projects uses [commitlint](https://commitlint.js.org/) with Angular configu
 Contributions should be validated with the command:
 
 ```bash
-codeclimate analyze
+$ codeclimate analyze
 ```
 
 See [codeclimate](https://github.com/codeclimate/codeclimate).
@@ -49,7 +49,7 @@ $ yarn test
 Style and lint errors should be fixed with
 
 ```bash
-yarn style:lint
+$ yarn style:lint
 ```
 
 ## Contributors

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ $ yarn
 # run tests
 $ yarn test
 # run the code linter
-$ yarn lint
+$ yarn style:lint
 # Build the lib
 $ yarn build
 # Test UI locally with mocked data
@@ -30,7 +30,7 @@ This projects uses [commitlint](https://commitlint.js.org/) with Angular configu
 Contributions should be validated with the command:
 
 ```bash
-$ codeclimate analyze
+codeclimate analyze
 ```
 
 See [codeclimate](https://github.com/codeclimate/codeclimate).
@@ -49,7 +49,7 @@ $ yarn test
 Style and lint errors should be fixed with
 
 ```bash
-$ yarn lint
+yarn style:lint
 ```
 
 ## Contributors

--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -1,7 +1,7 @@
 module.exports = {
     '*.{js,css,json,md,yaml,yml,ts,tsx,cjs}': ['prettier --write'],
     '*.md': (filenames) =>
-        filenames.map((filename) => `'markdown-toc -i ${filename}`),
+        filenames.map((filename) => `'markdown-toc -i \"${filename}\"`),
     '*.ts': [
         'npm run style:lint',
         'npm run style:prettier',

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "scripts": {
         "type": "tsc --noEmit",
         "style:lint": "eslint packages --ext .ts",
+        "style:lint-fix": "eslint packages --ext .ts --fix",
         "style:prettier": "prettier \"packages/**/*.ts\" --list-different --write",
         "build": "npx lerna run build",
         "bootstrap": "npx lerna bootstrap",

--- a/packages/gitlab/src/components/widgets/ReleasesCard/ReleasesCard.tsx
+++ b/packages/gitlab/src/components/widgets/ReleasesCard/ReleasesCard.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { Link, Grid } from '@material-ui/core';
+import { Link, Grid, Typography } from '@material-ui/core';
 import LocalOfferOutlinedIcon from '@material-ui/icons/LocalOfferOutlined';
 import Alert from '@material-ui/lab/Alert';
 import {
@@ -92,6 +92,11 @@ const sortFunctions: Record<
  */
 export interface ReleasesCardProps {
     /**
+     * Title - The title of the card shown on ReleaseCard component
+     */
+    title?: string;
+
+    /**
      * Filter
      *
      * all - show all releases (default)
@@ -146,6 +151,7 @@ function makeFilter(
  */
 export const ReleasesCard = (props: ReleasesCardProps) => {
     const {
+        title = 'Releases',
         show = 'all',
         limit = 6,
         sort = 'releasedDate',
@@ -217,8 +223,27 @@ export const ReleasesCard = (props: ReleasesCardProps) => {
     // sort the remaining releases in descending order (latest release first)
     releases = releases.slice(0, limit);
 
+    // if no releases were found, just render an empty widgets with a message
     if (releases.length === 0) {
-        return <></>;
+        return (
+            <InfoCard
+                title={title}
+                deepLink={{
+                    link: `${project_web_url}/-/releases`,
+                    title: 'go to Releases',
+                    onClick: (e) => {
+                        e.preventDefault();
+                        window.open(`${project_web_url}/-/releases`);
+                    },
+                }}
+                variant={props.variant}
+                className={classes.infoCard}
+            >
+                <Typography variant="body2">
+                    No releases have been made
+                </Typography>
+            </InfoCard>
+        );
     }
 
     const handleSortChange = (event: React.ChangeEvent<{ value: unknown }>) => {
@@ -227,7 +252,7 @@ export const ReleasesCard = (props: ReleasesCardProps) => {
 
     return (
         <InfoCard
-            title="Releases"
+            title={title}
             deepLink={{
                 link: `${project_web_url}/-/releases`,
                 title: 'go to Releases',


### PR DESCRIPTION
## 🚨 Proposed changes

### Frontend changes
The ReleaseCard component was updated to display only the message "No releases have been made" when no releases are received from the GitLab API; I think this is nicer than not rendering a card. A title property was also added to this card to enable plugin consumers to customize the ReleaseCard title with a default value of 'Releases'. This is related to this [issue](https://github.com/immobiliare/backstage-plugin-gitlab/issues/425).

### Project changes

- Updated CONTRIBUTING.md where it mentioned the yarn lint script, since in project.json, only style:lint was defined.
- Added a fix lint script into the project.json.
- In lint-staged.config.cjs the markdown-toc command was updated with escaped " to allow for paths with whitespace to be accepted.

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
