### PR TITLE
fix: translate relative readme links

### DIFF
--- a/packages/gitlab/dev/mock-gitlab/api-v4-v15.7.0.ts
+++ b/packages/gitlab/dev/mock-gitlab/api-v4-v15.7.0.ts
@@ -6455,6 +6455,8 @@ The official authentication server uses TLS encryption extensively. It also empl
 
 [Future plans](https://gitlab.com/veloren/veloren/-/milestones) - This is the development roadmap and what issues the community is currently working on.
 
+[Relative Link for testing](./CONTRIBUTING.md)
+
 ### Official social media and websites
 
 - [Website](https://veloren.net)

--- a/packages/gitlab/src/components/widgets/ReadmeCard/ReadmeCard.tsx
+++ b/packages/gitlab/src/components/widgets/ReadmeCard/ReadmeCard.tsx
@@ -22,7 +22,7 @@ import toc from 'remark-toc';
 import removeComments from 'remark-remove-comments';
 
 import gemoji from 'remark-gemoji';
-import { parseGitLabReadme } from '../../utils';
+import { parseGitLabReadme, resolveReadmeRelativelinks } from '../../utils';
 
 const useStyles = makeStyles((theme) => ({
     infoCard: {
@@ -106,8 +106,18 @@ export const ReadmeCard = (props: Props) => {
             readmeData = undefined;
         }
 
+        let processedReadme = readmeData;
+
+        if (readmeData) {
+            processedReadme = parseGitLabReadme(readmeData);
+            processedReadme = resolveReadmeRelativelinks(
+                processedReadme,
+                projectDetails
+            );
+        }
+
         return {
-            readme: readmeData ? parseGitLabReadme(readmeData) : undefined,
+            readme: processedReadme,
         };
     }, []);
 

--- a/packages/gitlab/src/plugin.test.ts
+++ b/packages/gitlab/src/plugin.test.ts
@@ -1,5 +1,10 @@
+import { ProjectSchema } from '@gitbeaker/rest';
+import {
+    parseCodeOwners,
+    parseGitLabReadme,
+    resolveReadmeRelativelinks,
+} from './components/utils';
 import { gitlabPlugin } from './plugin';
-import { parseCodeOwners, parseGitLabReadme } from './components/utils';
 
 const CODEOWNERS = `
 # Lines starting with '#' are comments.
@@ -25,6 +30,21 @@ const README = `## TOC
 [[_TOC_]]
 ## Heading 1
  [[_TOC_]] `;
+
+const README_WITH_LINKS = [
+    'This is relative [link](./link.md)',
+    'This is absolute [link](https://gitlab.com/link.md)',
+    '[Same-Line Relative Link](./link.md)',
+    '[Same-Line Absolute Link](https://gitlab.com/link.md)',
+    '[./link.md](./link.md)',
+    '[https://gitlab.com/link.md](https://gitlab.com/link.md)',
+    '[Dot Prefix Link](./link.md)',
+    '[Slash Prefix Link](/link.md)',
+    '[Dot Slash Prefix Link](./link.md)',
+    '[No Prefix Link](link.md)',
+    '[Link with Subdirectory](./subdir/link.md)',
+    '[Link with Subdirectory and Anchor](./subdir/link.md#anchor)',
+];
 
 describe('gitlabPlugin', () => {
     it('should export plugin', () => {
@@ -66,5 +86,27 @@ describe('gitlabPlugin', () => {
                 `## <!-- injected_toc -->`,
             ].join('\n')
         );
+    });
+
+    it('resolveReadmeRelativelinks works', async () => {
+        expect(
+            resolveReadmeRelativelinks(README_WITH_LINKS.join('\n'), {
+                web_url: 'https://gitlab.com/project',
+                default_branch: 'main',
+            } as ProjectSchema).split('\n')
+        ).toEqual([
+            'This is relative [link](https://gitlab.com/project/-/blob/main/link.md)',
+            'This is absolute [link](https://gitlab.com/link.md)',
+            '[Same-Line Relative Link](https://gitlab.com/project/-/blob/main/link.md)',
+            '[Same-Line Absolute Link](https://gitlab.com/link.md)',
+            '[https://gitlab.com/project/-/blob/main/link.md](https://gitlab.com/project/-/blob/main/link.md)',
+            '[https://gitlab.com/link.md](https://gitlab.com/link.md)',
+            '[Dot Prefix Link](https://gitlab.com/project/-/blob/main/link.md)',
+            '[Slash Prefix Link](https://gitlab.com/project/-/blob/main/link.md)',
+            '[Dot Slash Prefix Link](https://gitlab.com/project/-/blob/main/link.md)',
+            '[No Prefix Link](https://gitlab.com/project/-/blob/main/link.md)',
+            '[Link with Subdirectory](https://gitlab.com/project/-/blob/main/subdir/link.md)',
+            '[Link with Subdirectory and Anchor](https://gitlab.com/project/-/blob/main/subdir/link.md#anchor)',
+        ]);
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
         "incremental": true,
         "isolatedModules": true,
         "jsx": "react",
-        "lib": ["DOM", "DOM.Iterable", "ScriptHost", "ES2020"],
+        "lib": ["DOM", "DOM.Iterable", "ScriptHost", "ES2020", "ES2021.String"],
         "module": "ESNext",
         "moduleResolution": "node",
         "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
## 🚨 Proposed changes

Fixes https://github.com/immobiliare/backstage-plugin-gitlab/issues/524
Replaces relative links in readmes with their correct URLs using the web_url and branch details from the response.

Does not account for `../file.md`, but this would not be possible in GitLab anyway.

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [ ] New feature (non-breaking change which adds functionality)
-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
