### PR TITLE
fix: Update CODEOWNERS parsing to align to Gitlab's official regex

### DIFF
--- a/packages/gitlab/src/components/utils.tsx
+++ b/packages/gitlab/src/components/utils.tsx
@@ -111,9 +111,18 @@ const parseCodeOwnerLine = (rule: string): FileOwnership => {
     };
 };
 
-// ensures that only the following patterns are allowed @octocat @octocat/kitty docs@example.com
-const codeOwnerRegex =
-    /(^@[a-zA-Z0-9_\-/]*$)|(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/;
+// matches RCF 5322 compliant email addresses - taken from https://emailregex.com/
+const codeOwnersEmailRegex =
+    /(^(?:[a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$)/;
+
+// matches gitlab usernames - taken from https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/path_regex.rb#L127-135
+const codeOwnersGitlabUsernameRegex =
+    /(^@[a-zA-Z0-9_\.][a-zA-Z0-9_\-\.]{0,254}[a-zA-Z0-9_\-]|[a-zA-Z0-9_]$)/;
+
+// ensures that only the following patterns are allowed @octocat @github/js docs@example.com @octo.cat
+const codeOwnerRegex = new RegExp(
+    codeOwnersGitlabUsernameRegex.source + '|' + codeOwnersEmailRegex.source
+);
 
 // Remark does not fully support GLFM, but remark-toc can generate a TOC, but it requires a # heading, whereas GLFM does not.
 export const parseGitLabReadme = (readme: string): string => {

--- a/packages/gitlab/src/plugin.test.ts
+++ b/packages/gitlab/src/plugin.test.ts
@@ -11,10 +11,13 @@ const CODEOWNERS = `
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners
 # will be requested to review.
-*.js    @octocat @github/js
+*.js    @octocat @github/js @octo.cat
 
 # You can also use email addresses if you prefer.
-# docs/*  docs@example.com
+docs/*  docs@example.com
+
+# This rule is commented out and will not be parsed
+# tests/*       @antoniomuso
 `;
 
 const CODEOWNERS2 = `# Specify a default Code Owner by using a wildcard:
@@ -39,9 +42,14 @@ describe('gitlabPlugin', () => {
                 rule: '*       @antoniomuso',
             },
             {
-                owners: ['@octocat', '@github/js'],
+                owners: ['@octocat', '@github/js', '@octo.cat'],
                 path: '*.js',
-                rule: '*.js    @octocat @github/js',
+                rule: '*.js    @octocat @github/js @octo.cat',
+            },
+            {
+                owners: ['docs@example.com'],
+                path: 'docs/*',
+                rule: 'docs/*  docs@example.com',
             },
         ]);
     });


### PR DESCRIPTION
## 🚨 Proposed changes

> Please review the [guidelines for contributing](../../CONTRIBUTING.md) to this repository.

The current regex used for parsing CODEOWNERS files does not allow for usernames with a period in them (eg: @code.owner). This change updates the regex used to match the [official regex](https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/path_regex.rb#L127-135). 

Closes #558 #595 

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
