### PR TITLE
feat(backend): add support for empty string annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,25 @@ spec:
     # ...
 ```
 
+It's possible to disable the GitLab plugins and cards by setting these annotations to an empty string.
+
+This is useful if the entity (catalog-info.yaml) is hosted on GitLab but the actual source code is hosted
+somewhere else or GitLab isn't used for issue tracking.
+
+```yaml
+# Example catalog-info.yaml entity definition file
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+    # ...
+    annotations:
+        gitlab.com/instance: '' # don't show the issue and merge requests cards
+        gitlab.com/project-slug: ''
+spec:
+    type: service
+    # ...
+```
+
 ### Code owners file
 
 The plugins support also the `gitlab.com/codeowners-path` annotation:

--- a/packages/gitlab-backend/src/processor/processor.test.ts
+++ b/packages/gitlab-backend/src/processor/processor.test.ts
@@ -173,6 +173,54 @@ describe('Processor', () => {
         ).toBeUndefined();
     });
 
+    it('The processor does not update GITLAB_PROJECT_SLUG if the annotations GITLAB_PROJECT_ID or GITLAB_PROJECT_SLUG is empty', async () => {
+        const processor = new GitlabFillerProcessor(config);
+        const entity: Entity = {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+                name: 'backstage',
+                annotations: {
+                    [GITLAB_PROJECT_ID]: '',
+                },
+            },
+        };
+        await processor.postProcessEntity(
+            entity,
+            {
+                type: 'url',
+                target: 'https://my.custom-gitlab.com/backstage/backstage/blob/next/catalog.yaml',
+            },
+            () => undefined
+        );
+
+        expect(entity.metadata?.annotations?.[GITLAB_PROJECT_ID]).toEqual('');
+    });
+
+    it('The processor does not update GITLAB_INSTANCE if the annotation is empty', async () => {
+        const processor = new GitlabFillerProcessor(config);
+        const entity: Entity = {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+                name: 'backstage',
+                annotations: {
+                    [GITLAB_INSTANCE]: '',
+                },
+            },
+        };
+        await processor.postProcessEntity(
+            entity,
+            {
+                type: 'url',
+                target: 'https://my.custom-gitlab.com/backstage/backstage/blob/next/catalog.yaml',
+            },
+            () => undefined
+        );
+
+        expect(entity.metadata?.annotations?.[GITLAB_INSTANCE]).toEqual('');
+    });
+
     it('The processor does not update annotation if the location is not a gitlab instance', async () => {
         const processor = new GitlabFillerProcessor(config);
         const entity: Entity = {

--- a/packages/gitlab-backend/src/processor/processor.ts
+++ b/packages/gitlab-backend/src/processor/processor.ts
@@ -54,18 +54,24 @@ export class GitlabFillerProcessor implements CatalogProcessor {
                 if (!entity.metadata.annotations)
                     entity.metadata.annotations = {};
 
-                // Set GitLab Instance
-                if (!entity.metadata.annotations?.[GITLAB_INSTANCE]) {
-                    entity.metadata.annotations![GITLAB_INSTANCE] =
+                // Set GitLab Instance when it's there yet, but handle an empty string as specified.
+                if (
+                    !entity.metadata.annotations[GITLAB_INSTANCE] &&
+                    entity.metadata.annotations[GITLAB_INSTANCE] !== ''
+                ) {
+                    entity.metadata.annotations[GITLAB_INSTANCE] =
                         gitlabInstanceConfig?.host;
                 }
 
-                // Generate Project Slug from location URL if neither Project ID nor Project Slug are specified
+                // Generate Project Slug from location URL if neither Project ID nor Project Slug are specified.
+                // Handle empty strings as specified.
                 if (
-                    !entity.metadata.annotations?.[GITLAB_PROJECT_ID] &&
-                    !entity.metadata.annotations?.[GITLAB_PROJECT_SLUG]
+                    !entity.metadata.annotations[GITLAB_PROJECT_ID] &&
+                    entity.metadata.annotations[GITLAB_PROJECT_ID] !== '' &&
+                    !entity.metadata.annotations[GITLAB_PROJECT_SLUG] &&
+                    entity.metadata.annotations[GITLAB_PROJECT_SLUG] !== ''
                 ) {
-                    entity.metadata.annotations![GITLAB_PROJECT_SLUG] =
+                    entity.metadata.annotations[GITLAB_PROJECT_SLUG] =
                         getProjectPath(
                             location.target,
                             this.getGitlabSubPath(gitlabInstanceConfig)


### PR DESCRIPTION
## 🚨 Proposed changes

Thanks for the work you spend on this plugin.

When hosting a catalog entity in a GitLab instance (hosting the `catalog-info.yaml` there) the backend automatically applies the `gitlab.com/instance` and `gitlab.com/project-slug` annotation.

Currently, there is no way to opt out of that for an individual entity, whether the source code is hosted elsewhere or for entities without source code, and which issues are tracked elsewhere (for example, in Jira).

Without this change, the processor already respects custom annotations.

With this change, the processor also ignores entities that set an empty string for these annotations.

```yaml
apiVersion: backstage.io/v1alpha1
kind: Component
metadata:
  # ...
  annotations:
    gitlab.com/instance: ""
    gitlab.com/project-slug: ""
spec:
  # ...
```

This is something between a feature and a bugfix. (A breaking change only if someone used an empty string before.)

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [x] New feature (non-breaking change which adds functionality)
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
