### PR TITLE
fix(ReadmeCard): Re-render when the Gitlab ids change

### DIFF
--- a/packages/gitlab/src/components/widgets/ReadmeCard/ReadmeCard.tsx
+++ b/packages/gitlab/src/components/widgets/ReadmeCard/ReadmeCard.tsx
@@ -109,7 +109,7 @@ export const ReadmeCard = (props: Props) => {
         return {
             readme: readmeData ? parseGitLabReadme(readmeData) : undefined,
         };
-    }, []);
+    }, [project_id, project_slug]);
 
     if (loading) {
         return <Progress />;


### PR DESCRIPTION
## 🚨 Proposed changes

** Problem **

The component does not re-render the README when the gitlab ids in the context change. This is due to the fact that no dependencies in useAsync are defined.

** Solution **

Specify the proper dependencies which influence the data loaded.

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
