### PR TITLE
fix: Add readme_path to the dependencies of ReadmeCard

### DIFF
--- a/packages/gitlab/src/components/widgets/ReadmeCard/ReadmeCard.tsx
+++ b/packages/gitlab/src/components/widgets/ReadmeCard/ReadmeCard.tsx
@@ -109,7 +109,7 @@ export const ReadmeCard = (props: Props) => {
         return {
             readme: readmeData ? parseGitLabReadme(readmeData) : undefined,
         };
-    }, [project_id, project_slug]);
+    }, [project_id, project_slug, readme_path]);
 
     if (loading) {
         return <Progress />;


### PR DESCRIPTION
## 🚨 Proposed changes

Missed this one in the previous MR, when the readme path changes we want to re-render as well.

## ⚙️ Types of changes

-   [x] Bugfix (non-breaking change which fixes an issue)
