### PR TITLE
feat: add members list in people card

### DIFF
--- a/packages/gitlab/dev/mock-gitlab/api-v4-v15.7.0.ts
+++ b/packages/gitlab/dev/mock-gitlab/api-v4-v15.7.0.ts
@@ -2140,6 +2140,30 @@ export const mockedGitlabReqToRes: Record<string, any> = {
             deletions: 0,
         },
     ],
+    'projects/10174980/members/all?': [
+        {
+            access_level: 50,
+            membership_state: 'active',
+            id: 7487985,
+            username: 'cpetig',
+            name: 'Christof Petig',
+            state: 'active',
+            avatar_url:
+                'https://gitlab.com/uploads/-/system/user/avatar/7487985/avatar.png',
+            web_url: 'https://gitlab.com/cpetig',
+        },
+        {
+            access_level: 30,
+            membership_state: 'active',
+            id: 8152986,
+            username: 'papiris',
+            name: 'Jacob Ludvigsen',
+            state: 'active',
+            avatar_url:
+                'https://secure.gravatar.com/avatar/a195cbacfdf18e635ab956fc17fcd580?s=80\u0026d=identicon',
+            web_url: 'https://gitlab.com/papiris',
+        },
+    ],
     'projects/10174980/issues?': [
         {
             id: 120368248,

--- a/packages/gitlab/src/api/GitlabCIApi.ts
+++ b/packages/gitlab/src/api/GitlabCIApi.ts
@@ -7,11 +7,14 @@ import type {
     ProjectSchema,
     ReleaseSchema,
     RepositoryContributorSchema,
+    RepositoryMemberSchema,
     UserSchema,
 } from '@gitbeaker/rest';
 
 export type ContributorsSummary = (RepositoryContributorSchema &
     Partial<UserSchema>)[];
+
+export type MembersSummary = (RepositoryMemberSchema & Partial<UserSchema>)[];
 
 export type LanguagesSummary = Languages;
 
@@ -48,6 +51,9 @@ export type GitlabCIApi = {
     getContributorsSummary(
         projectID: string | number
     ): Promise<ContributorsSummary | undefined>;
+    getMembersSummary(
+        projectID: string | number
+    ): Promise<MembersSummary | undefined>;
     getMergeRequestsSummary(
         projectID: string | number
     ): Promise<MergeRequestSchema[] | undefined>;
@@ -79,6 +85,7 @@ export type GitlabCIApi = {
         projectWebUrl: string,
         projectDefaultBranch: string
     ): string;
+    getMembersLink(projectWebUrl: string): string;
     getOwnersLink(
         projectWebUrl: string,
         projectDefaultBranch: string,

--- a/packages/gitlab/src/api/index.ts
+++ b/packages/gitlab/src/api/index.ts
@@ -2,6 +2,7 @@ export type {
     GitlabCIApi,
     LanguagesSummary,
     ContributorsSummary,
+    MembersSummary,
 } from './GitlabCIApi';
 export { GitlabCIApiRef } from './GitlabCIApi';
 export { GitlabCIClient } from './GitlabCIClient';

--- a/packages/gitlab/src/components/types.ts
+++ b/packages/gitlab/src/components/types.ts
@@ -17,6 +17,20 @@ export type PeopleLink = {
     onClick: MouseEventHandler;
 };
 
+export type MemberCardEntityData = {
+    name: string;
+    email?: string;
+    avatar_url?: string;
+    id?: number;
+    state?: string;
+    username?: string;
+    web_url?: string;
+    full_path?: string;
+    access_level?: number;
+    access_level_label?: string;
+    membership_state?: string;
+};
+
 export type FileOwnership = {
     rule: string;
     path: string;

--- a/packages/gitlab/src/components/widgets/PeopleCard/PeopleCard.tsx
+++ b/packages/gitlab/src/components/widgets/PeopleCard/PeopleCard.tsx
@@ -16,7 +16,9 @@ import {
     gitlabInstance,
 } from '../../gitlabAppData';
 import { PeopleList } from './components/PeopleList';
+import { MembersList } from './components/MembersList';
 import { PeopleCardEntityData, PeopleLink } from '../../types';
+import { MemberCardEntityData } from '../../types';
 import { Divider } from '@material-ui/core';
 import { ProjectSchema } from '@gitbeaker/rest';
 
@@ -53,6 +55,7 @@ export const PeopleCard = (props: Props) => {
     /* TODO: to change the below logic to get contributors data*/
     const { value, loading, error } = useAsync(async (): Promise<{
         contributors: PeopleCardEntityData[] | undefined;
+        members: MemberCardEntityData[] | undefined;
         owners: PeopleCardEntityData[] | undefined;
         projectDetails: ProjectSchema;
     }> => {
@@ -63,6 +66,10 @@ export const PeopleCard = (props: Props) => {
             throw new Error('wrong project_slug or project_id');
 
         const contributorData = await GitlabCIAPI.getContributorsSummary(
+            projectDetails.id
+        );
+
+        const memberData = await GitlabCIAPI.getMembersSummary(
             projectDetails.id
         );
 
@@ -79,6 +86,7 @@ export const PeopleCard = (props: Props) => {
         }
         return {
             contributors: contributorData!,
+            members: memberData!,
             owners: codeOwners,
             projectDetails,
         };
@@ -88,6 +96,7 @@ export const PeopleCard = (props: Props) => {
     const project_default_branch = value?.projectDetails?.default_branch;
 
     let contributorsDeepLink: PeopleLink | undefined;
+    let membersDeepLink: PeopleLink | undefined;
     let ownersDeepLink: PeopleLink | undefined;
     if (project_web_url && project_default_branch) {
         const contributorsLink = GitlabCIAPI.getContributorsLink(
@@ -100,6 +109,16 @@ export const PeopleCard = (props: Props) => {
             onClick: (e) => {
                 e.preventDefault();
                 window.open(contributorsLink);
+            },
+        };
+
+        const membersLink = GitlabCIAPI.getMembersLink(project_web_url);
+        membersDeepLink = {
+            link: membersLink,
+            title: 'go to Members',
+            onClick: (e) => {
+                e.preventDefault();
+                window.open(membersLink);
             },
         };
 
@@ -148,6 +167,13 @@ export const PeopleCard = (props: Props) => {
                 title="Contributors"
                 peopleObj={value?.contributors || []}
                 deepLink={contributorsDeepLink}
+            />
+
+            <Divider className={classes.divider}></Divider>
+            <MembersList
+                title="Members"
+                memberObj={value?.members || []}
+                deepLink={membersDeepLink}
             />
         </InfoCard>
     );

--- a/packages/gitlab/src/components/widgets/PeopleCard/components/MemberCardEntity/MemberCardEntity.tsx
+++ b/packages/gitlab/src/components/widgets/PeopleCard/components/MemberCardEntity/MemberCardEntity.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Avatar, Tooltip } from '@material-ui/core';
+import { withStyles } from '@material-ui/core/styles';
+import { MemberCardEntityData } from '../../../../types';
+
+type Props = {
+    memberCardEntity: MemberCardEntityData;
+};
+
+const LightTooltip = withStyles({
+    tooltip: {
+        backgroundColor: 'white',
+        border: '1px solid lightgrey',
+        color: '#333',
+        minWidth: '320px',
+    },
+})(Tooltip);
+
+export const MemberCardEntity = ({
+    memberCardEntity: memberCardEntity,
+}: Props) => {
+    return (
+        <LightTooltip
+            title={[memberCardEntity.name, memberCardEntity.access_level_label]
+                .filter(Boolean)
+                .join(' : ')}
+        >
+            <a href={memberCardEntity.web_url} target="_blank">
+                <Avatar
+                    key={memberCardEntity.name}
+                    alt={memberCardEntity.name}
+                    src={memberCardEntity.avatar_url}
+                />
+            </a>
+        </LightTooltip>
+    );
+};

--- a/packages/gitlab/src/components/widgets/PeopleCard/components/MemberCardEntity/index.tsx
+++ b/packages/gitlab/src/components/widgets/PeopleCard/components/MemberCardEntity/index.tsx
@@ -1,0 +1,1 @@
+export { MemberCardEntity } from './MemberCardEntity';

--- a/packages/gitlab/src/components/widgets/PeopleCard/components/MembersList/MembersList.tsx
+++ b/packages/gitlab/src/components/widgets/PeopleCard/components/MembersList/MembersList.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Grid, Box } from '@material-ui/core';
+import { Link } from '@backstage/core-components';
+import { MemberCardEntity } from '../MemberCardEntity';
+import { MemberCardEntityData, PeopleLink } from '../../../../types';
+import { makeStyles } from '@material-ui/core/styles';
+import ArrowIcon from '@material-ui/icons/ArrowForward';
+
+interface MembersListProps {
+    title: string;
+    memberObj: MemberCardEntityData[];
+    deepLink?: PeopleLink;
+}
+
+const useStyles = makeStyles((theme) => ({
+    link: {
+        color: 'inherit',
+        textDecoration: 'none',
+        marginRight: theme.spacing(1),
+        marginTop: theme.spacing(0),
+    },
+    box: {
+        marginTop: theme.spacing(0),
+        marginBottom: theme.spacing(1),
+    },
+    boxLink: {
+        marginTop: theme.spacing(0),
+    },
+    title: {
+        marginTop: theme.spacing(0),
+        marginBottom: theme.spacing(0),
+    },
+}));
+
+export const MembersList = ({
+    title,
+    memberObj: peopleObj,
+    deepLink,
+}: MembersListProps) => {
+    const classes = useStyles();
+    return (
+        <>
+            <Box
+                className={classes.box}
+                display="flex"
+                alignItems="center"
+                justifyContent="space-between"
+            >
+                <h2 className={classes.title}>{title}</h2>
+                {deepLink && (
+                    <Box
+                        className={classes.boxLink}
+                        display="flex"
+                        alignItems="center"
+                    >
+                        <Link
+                            className={classes.link}
+                            to={deepLink.link}
+                            onClick={deepLink.onClick}
+                        >
+                            {deepLink.title}
+                        </Link>
+                        <ArrowIcon fontSize="small"></ArrowIcon>
+                    </Box>
+                )}
+            </Box>
+            <Grid container spacing={1} justifyContent="flex-start">
+                {peopleObj?.map((memberCardEntity: MemberCardEntityData) => (
+                    <Grid key={memberCardEntity.name} item>
+                        <MemberCardEntity memberCardEntity={memberCardEntity} />
+                    </Grid>
+                ))}
+            </Grid>
+        </>
+    );
+};

--- a/packages/gitlab/src/components/widgets/PeopleCard/components/MembersList/index.tsx
+++ b/packages/gitlab/src/components/widgets/PeopleCard/components/MembersList/index.tsx
@@ -1,0 +1,1 @@
+export { MembersList } from './MembersList';


### PR DESCRIPTION
## 🚨 Proposed changes

> Please review the [guidelines for contributing](../../CONTRIBUTING.md) to this repository.

Feature request (see https://github.com/immobiliare/backstage-plugin-gitlab/issues/738) : display members allowed on a gitlab project, and with what role (developer, owner, ...). This list is added in "People card", under "Contributors" list.

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
