### PR TITLE
feat: Project ID annotation processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ gitlab:
     # Activate Oauth/OIDC
     # Default: false
     useOAuth: false
+    # Automatically fetch project IDs from GitLab
+    # Default: false
+    projectIdExtraction: true
     # Cache configuration
     cache:
         # Enable caching for the Gitlab plugin
@@ -280,6 +283,7 @@ If you're already using the [New Backend System](https://backstage.io/docs/backe
 import {
     gitlabPlugin,
     catalogPluginGitlabFillerProcessorModule,
+    catalogPluginGitlabProjectIdProcessorModule,
 } from '@immobiliarelabs/backstage-plugin-gitlab-backend';
 
 async function start() {
@@ -288,6 +292,7 @@ async function start() {
     // ...
     backend.add(gitlabPlugin);
     backend.add(catalogPluginGitlabFillerProcessorModule);
+    backend.add(catalogPluginGitlabProjectIdProcessorModule);
 
     // ...
 }

--- a/packages/gitlab-backend/config.d.ts
+++ b/packages/gitlab-backend/config.d.ts
@@ -20,5 +20,12 @@ export interface Config {
          * @visibility backend
          */
         useOAuth?: boolean;
+
+        /**
+         * Enable automatic project id extraction using the GitLab API
+         * @default false
+         * @visibility backend
+         */
+        projectIdExtraction?: boolean;
     };
 }

--- a/packages/gitlab-backend/src/plugin.ts
+++ b/packages/gitlab-backend/src/plugin.ts
@@ -5,6 +5,7 @@ import {
 } from '@backstage/backend-plugin-api';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
 import { GitlabFillerProcessor } from './processor';
+import { GitlabProjectIdProcessor } from './processor/projectIdProcessor';
 import { createRouter } from './service/router';
 
 export const catalogPluginGitlabFillerProcessorModule = createBackendModule({
@@ -18,6 +19,27 @@ export const catalogPluginGitlabFillerProcessorModule = createBackendModule({
             },
             async init({ config, extensionPoint }) {
                 extensionPoint.addProcessor(new GitlabFillerProcessor(config));
+            },
+        });
+    },
+});
+
+export const catalogPluginGitlabProjectIdProcessorModule = createBackendModule({
+    pluginId: 'catalog',
+    moduleId: 'gitlabProjectIdProcessor',
+    register(env) {
+        env.registerInit({
+            deps: {
+                config: coreServices.rootConfig,
+                extensionPoint: catalogProcessingExtensionPoint,
+                cache: coreServices.cache,
+            },
+            async init({ config, extensionPoint, cache }) {
+                if (config.getOptionalBoolean('gitlab.projectIdExtraction')) {
+                    extensionPoint.addProcessor(
+                        new GitlabProjectIdProcessor(config, cache)
+                    );
+                }
             },
         });
     },

--- a/packages/gitlab-backend/src/processor/index.ts
+++ b/packages/gitlab-backend/src/processor/index.ts
@@ -1,1 +1,2 @@
 export * from './processor';
+export * from './projectIdProcessor';

--- a/packages/gitlab-backend/src/processor/projectIdProcessor.test.ts
+++ b/packages/gitlab-backend/src/processor/projectIdProcessor.test.ts
@@ -1,0 +1,85 @@
+import { GitlabProjectIdProcessor } from './projectIdProcessor';
+import { ConfigReader } from '@backstage/config';
+import { Entity } from '@backstage/catalog-model';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import {
+    GITLAB_PROJECT_SLUG,
+    GITLAB_PROJECT_ID,
+    GITLAB_INSTANCE,
+} from '../annotations';
+
+describe('GitlabProjectIdProcessor', () => {
+    const server = setupServer(
+        rest.get(
+            'http://localhost/api/gitlab/rest/gitlab.example.com/projects/customer%2Fxyz',
+            (_req, res, ctx) => res(ctx.json({ id: 55 }))
+        )
+    );
+
+    beforeAll(() => server.listen());
+    afterEach(() => server.resetHandlers());
+    afterAll(() => server.close());
+
+    const config = new ConfigReader({
+        backend: { baseUrl: 'http://localhost' },
+    });
+
+    const createCache = (): any => {
+        const store: Record<string, string> = {};
+        return {
+            get: jest.fn(async (k: string) => store[k]),
+            set: jest.fn(async (k: string, v: string) => {
+                store[k] = v;
+            }),
+            delete: jest.fn(async (k: string) => {
+                delete store[k];
+            }),
+            withOptions: jest.fn(() => createCache()),
+        };
+    };
+
+    it('adds project id from api', async () => {
+        const cache = createCache();
+        const processor = new GitlabProjectIdProcessor(config, cache as any);
+        const entity: Entity = {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+                name: 'test',
+                annotations: {
+                    [GITLAB_PROJECT_SLUG]: 'customer/xyz',
+                    [GITLAB_INSTANCE]: 'gitlab.example.com',
+                },
+            },
+        };
+
+        await processor.postProcessEntity(entity);
+
+        expect(entity.metadata?.annotations?.[GITLAB_PROJECT_ID]).toBe('55');
+    });
+
+    it('uses cached project id', async () => {
+        const cache = createCache();
+        await cache.set(
+            'gitlab-project-id:gitlab.example.com:customer/xyz',
+            '42'
+        );
+        const processor = new GitlabProjectIdProcessor(config, cache as any);
+        const entity: Entity = {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+                name: 'test',
+                annotations: {
+                    [GITLAB_PROJECT_SLUG]: 'customer/xyz',
+                    [GITLAB_INSTANCE]: 'gitlab.example.com',
+                },
+            },
+        };
+
+        await processor.postProcessEntity(entity);
+
+        expect(entity.metadata?.annotations?.[GITLAB_PROJECT_ID]).toBe('42');
+    });
+});

--- a/packages/gitlab-backend/src/processor/projectIdProcessor.ts
+++ b/packages/gitlab-backend/src/processor/projectIdProcessor.ts
@@ -32,7 +32,8 @@ export class GitlabProjectIdProcessor implements CatalogProcessor {
         try {
             const cached = await this.cache.get<string>(cacheKey);
             if (cached) {
-                annotations![GITLAB_PROJECT_ID] = cached;
+                entity.metadata.annotations = entity.metadata.annotations || {};
+                entity.metadata.annotations[GITLAB_PROJECT_ID] = cached;
                 return entity;
             }
 

--- a/packages/gitlab-backend/src/processor/projectIdProcessor.ts
+++ b/packages/gitlab-backend/src/processor/projectIdProcessor.ts
@@ -1,0 +1,65 @@
+import { CatalogProcessor } from '@backstage/plugin-catalog-node';
+import { Entity } from '@backstage/catalog-model';
+import { Config } from '@backstage/config';
+import { CacheService } from '@backstage/backend-plugin-api';
+import {
+    GITLAB_INSTANCE,
+    GITLAB_PROJECT_ID,
+    GITLAB_PROJECT_SLUG,
+} from '../annotations';
+
+/** @public */
+export class GitlabProjectIdProcessor implements CatalogProcessor {
+    constructor(
+        private readonly config: Config,
+        private readonly cache: CacheService
+    ) {}
+
+    getProcessorName(): string {
+        return 'GitlabProjectIdProcessor';
+    }
+
+    async postProcessEntity(entity: Entity): Promise<Entity> {
+        const annotations = entity.metadata?.annotations;
+        const slug = annotations?.[GITLAB_PROJECT_SLUG];
+        const host = annotations?.[GITLAB_INSTANCE];
+
+        if (!slug || !host || annotations?.[GITLAB_PROJECT_ID] !== undefined) {
+            return entity;
+        }
+
+        const cacheKey = `gitlab-project-id:${host}:${slug}`;
+        try {
+            const cached = await this.cache.get<string>(cacheKey);
+            if (cached) {
+                annotations![GITLAB_PROJECT_ID] = cached;
+                return entity;
+            }
+
+            const baseUrl = this.config
+                .getString('backend.baseUrl')
+                .replace(/\/$/, '');
+            const url = `${baseUrl}/api/gitlab/rest/${host}/projects/${encodeURIComponent(
+                slug
+            )}`;
+            const response = await fetch(url);
+            if (!response.ok) {
+                console.warn(
+                    `GitLab proxy returned ${response.status} for ${slug}`
+                );
+                return entity;
+            }
+
+            const project = await response.json();
+            if (project?.id) {
+                const id = String(project.id);
+                annotations![GITLAB_PROJECT_ID] = id;
+                await this.cache.set(cacheKey, id);
+            }
+        } catch (err) {
+            console.error('Failed to call GitLab proxy:', err);
+        }
+
+        return entity;
+    }
+}


### PR DESCRIPTION
## 🚨 Proposed changes

> Please review the [guidelines for contributing](../../CONTRIBUTING.md) to this repository.

This PR introduces a new processor that, if enabled, fetch the project ID and add a specific annotation to the catalog entity.

The processor rely on the Backstage cache to reduce the impact of the iteration.

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor

Resolve [Project ID annotation implementation #859](https://arc.net/l/quote/drxwmfjz)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an optional setting to automatically extract GitLab project IDs for catalog entities.
  * Added a new processor module to support project ID extraction when enabled.
* **Documentation**
  * Updated documentation to describe the new configuration option and provide an example of backend plugin registration with the new module.
* **Tests**
  * Added tests to verify project ID extraction and caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->