### PR TITLE
fix(api): handle active members without membership_state in getUserMe…

### DIFF
--- a/packages/gitlab/src/api/GitlabCIClient.ts
+++ b/packages/gitlab/src/api/GitlabCIClient.ts
@@ -326,8 +326,9 @@ export class GitlabCIClient implements GitlabCIApi {
         return membersData
             .filter(
                 (member) =>
-                    member.state == 'active' &&
-                    (member.membership_state == 'active' || !member.membership_state)
+                    member.state === 'active' &&
+                    (member.membership_state === undefined ||
+                        member.membership_state === 'active')
             )
             .map((member) => {
                 // Access level label determination (https://docs.gitlab.com/api/members/)

--- a/packages/gitlab/src/api/GitlabCIClient.ts
+++ b/packages/gitlab/src/api/GitlabCIClient.ts
@@ -322,11 +322,12 @@ export class GitlabCIClient implements GitlabCIApi {
     private async getUserMembersData(
         membersData: SimpleMemberSchema[]
     ): Promise<MembersSummary> {
+        // If membership_state doesn't exist, but state is active, we can consider the user as active member. This is to handle the case when the API doesn't return membership_state for some users.
         return membersData
             .filter(
                 (member) =>
                     member.state == 'active' &&
-                    member.membership_state == 'active'
+                    (member.membership_state == 'active' || !member.membership_state)
             )
             .map((member) => {
                 // Access level label determination (https://docs.gitlab.com/api/members/)

--- a/packages/gitlab/src/api/GitlabCIClient.ts
+++ b/packages/gitlab/src/api/GitlabCIClient.ts
@@ -326,9 +326,9 @@ export class GitlabCIClient implements GitlabCIApi {
         return membersData
             .filter(
                 (member) =>
-                    member.state === 'active' &&
-                    (member.membership_state === undefined ||
-                        member.membership_state === 'active')
+                    member.membership_state === 'active' ||
+                    (member.membership_state === undefined &&
+                        member.state === 'active')
             )
             .map((member) => {
                 // Access level label determination (https://docs.gitlab.com/api/members/)


### PR DESCRIPTION
## 🚨 Proposed changes

On our setup the API /api/gitlab/rest/<gitlab_url>/projects/<project_id>/members/all? doesn't return membership_state but only state. If members only have member.state, they aren't shown on members card. I wanted to include handling the case membership_state is not given but state is given.

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected member filtering in the GitLab integration to more accurately identify active members, including cases where membership state is absent, improving member status recognition and sync reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->